### PR TITLE
Implement Leap Year Validation Function

### DIFF
--- a/src/leap_year.py
+++ b/src/leap_year.py
@@ -1,0 +1,26 @@
+def is_leap_year(year):
+    """
+    Determine if a given year is a leap year.
+    
+    A leap year is defined as:
+    - A year divisible by 4 
+    - Except if it's divisible by 100, it must also be divisible by 400
+    
+    Args:
+        year (int): The year to check
+    
+    Returns:
+        bool: True if the year is a leap year, False otherwise
+    
+    Raises:
+        ValueError: If the input is not a positive integer
+    """
+    # Validate input
+    if not isinstance(year, int):
+        raise ValueError("Year must be an integer")
+    
+    if year <= 0:
+        raise ValueError("Year must be a positive integer")
+    
+    # Leap year calculation
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)

--- a/tests/test_leap_year.py
+++ b/tests/test_leap_year.py
@@ -1,0 +1,33 @@
+import pytest
+from src.leap_year import is_leap_year
+
+def test_typical_leap_years():
+    """Test typical leap years"""
+    assert is_leap_year(2000) == True
+    assert is_leap_year(2004) == True
+    assert is_leap_year(2020) == True
+    assert is_leap_year(2024) == True
+
+def test_non_leap_years():
+    """Test non-leap years"""
+    assert is_leap_year(1900) == False
+    assert is_leap_year(2100) == False
+    assert is_leap_year(2001) == False
+    assert is_leap_year(2003) == False
+
+def test_century_exceptions():
+    """Test century years with special leap year rules"""
+    assert is_leap_year(2000) == True  # Divisible by 400
+    assert is_leap_year(1900) == False  # Divisible by 100 but not 400
+    assert is_leap_year(2100) == False  # Divisible by 100 but not 400
+
+def test_invalid_inputs():
+    """Test invalid input handling"""
+    with pytest.raises(ValueError, match="Year must be an integer"):
+        is_leap_year("2020")
+    
+    with pytest.raises(ValueError, match="Year must be a positive integer"):
+        is_leap_year(0)
+    
+    with pytest.raises(ValueError, match="Year must be a positive integer"):
+        is_leap_year(-2020)


### PR DESCRIPTION
# Implement Leap Year Validation Function

## Task
Write a function to determine if a given year is a leap year.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new function `isLeapYear()` to check if a given year is a leap year. The function follows the standard leap year rules:
- Years divisible by 4 are leap years
- Except years divisible by 100 are not leap years
- Unless they are also divisible by 400, in which case they are leap years

## Test Cases
 - Verifies that years divisible by 4 are correctly identified as leap years
 - Confirms that century years not divisible by 400 are not leap years
 - Checks that years divisible by 400 are correctly identified as leap years
 - Ensures years not meeting leap year criteria are correctly identified as non-leap years