### PR TITLE
Implement Celsius to Fahrenheit Conversion Function

### DIFF
--- a/src/temperature_converter.py
+++ b/src/temperature_converter.py
@@ -1,0 +1,17 @@
+def celsius_to_fahrenheit(celsius):
+    """
+    Convert Celsius temperature to Fahrenheit.
+    
+    Args:
+        celsius (float): Temperature in Celsius
+    
+    Returns:
+        float: Temperature in Fahrenheit
+    
+    Raises:
+        TypeError: If input is not a number
+    """
+    if not isinstance(celsius, (int, float)):
+        raise TypeError("Input must be a number")
+    
+    return (celsius * 9/5) + 32

--- a/tests/test_temperature_converter.py
+++ b/tests/test_temperature_converter.py
@@ -1,0 +1,23 @@
+import pytest
+from src.temperature_converter import celsius_to_fahrenheit
+
+def test_freezing_point():
+    """Test the freezing point of water (0°C = 32°F)"""
+    assert celsius_to_fahrenheit(0) == 32
+
+def test_boiling_point():
+    """Test the boiling point of water (100°C = 212°F)"""
+    assert celsius_to_fahrenheit(100) == 212
+
+def test_negative_temperature():
+    """Test a negative temperature conversion"""
+    assert celsius_to_fahrenheit(-40) == -40
+
+def test_fractional_temperature():
+    """Test conversion of a fractional temperature"""
+    assert abs(celsius_to_fahrenheit(37.5) - 99.5) < 0.001
+
+def test_invalid_input_type():
+    """Test that non-numeric input raises a TypeError"""
+    with pytest.raises(TypeError):
+        celsius_to_fahrenheit("not a number")


### PR DESCRIPTION
# Implement Celsius to Fahrenheit Conversion Function

## Task
Write a function to convert Celsius to Fahrenheit.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new utility function to convert temperatures from Celsius to Fahrenheit. The function takes a Celsius temperature as input and returns the equivalent Fahrenheit temperature using the standard conversion formula (F = C * 9/5 + 32).

## Test Cases
 - Verifies the function correctly converts 0°C to 32°F
 - Checks conversion of a negative temperature
 - Ensures accurate conversion of a positive temperature
 - Validates handling of decimal input temperatures