### PR TITLE
Implement Celsius to Fahrenheit Conversion Function

### DIFF
--- a/src/temperature_converter.py
+++ b/src/temperature_converter.py
@@ -1,0 +1,17 @@
+def celsius_to_fahrenheit(celsius):
+    """
+    Convert temperature from Celsius to Fahrenheit.
+    
+    Args:
+        celsius (float): Temperature in Celsius
+    
+    Returns:
+        float: Temperature converted to Fahrenheit
+    
+    Raises:
+        TypeError: If input is not a number
+    """
+    if not isinstance(celsius, (int, float)):
+        raise TypeError("Input must be a number")
+    
+    return (celsius * 9/5) + 32

--- a/tests/test_temperature_converter.py
+++ b/tests/test_temperature_converter.py
@@ -1,0 +1,26 @@
+import pytest
+from src.temperature_converter import celsius_to_fahrenheit
+
+def test_celsius_to_fahrenheit_positive():
+    """Test conversion of a positive temperature"""
+    assert celsius_to_fahrenheit(0) == 32
+    assert celsius_to_fahrenheit(100) == 212
+    assert celsius_to_fahrenheit(37) == 98.6
+
+def test_celsius_to_fahrenheit_negative():
+    """Test conversion of a negative temperature"""
+    assert celsius_to_fahrenheit(-40) == -40
+    assert celsius_to_fahrenheit(-17.78) == 0
+
+def test_celsius_to_fahrenheit_float():
+    """Test conversion with float values"""
+    assert round(celsius_to_fahrenheit(25.5), 1) == 77.9
+
+def test_celsius_to_fahrenheit_invalid_input():
+    """Test error handling for invalid input types"""
+    with pytest.raises(TypeError):
+        celsius_to_fahrenheit("not a number")
+    with pytest.raises(TypeError):
+        celsius_to_fahrenheit(None)
+    with pytest.raises(TypeError):
+        celsius_to_fahrenheit([1, 2, 3])


### PR DESCRIPTION
# Implement Celsius to Fahrenheit Conversion Function

## Task
Write a function to convert Celsius to Fahrenheit.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new utility function to convert temperatures from Celsius to Fahrenheit. The function takes a Celsius temperature as input and returns its equivalent in Fahrenheit using the standard conversion formula (F = C * 9/5 + 32).

## Test Cases
 - Verifies that the conversion function correctly transforms 0°C to 32°F
 - Checks the conversion of a negative temperature from Celsius to Fahrenheit
 - Ensures the function handles decimal temperature inputs accurately
 - Validates the conversion of a positive temperature above zero
 - Confirms the function returns the correct Fahrenheit value for a given Celsius input