### PR TITLE
Implement Fahrenheit to Celsius Temperature Conversion

### DIFF
--- a/src/temperature_converter.py
+++ b/src/temperature_converter.py
@@ -1,0 +1,19 @@
+def fahrenheit_to_celsius(fahrenheit: float) -> float:
+    """
+    Convert temperature from Fahrenheit to Celsius.
+    
+    Args:
+        fahrenheit (float): Temperature in Fahrenheit
+    
+    Returns:
+        float: Temperature converted to Celsius
+    
+    Raises:
+        TypeError: If input is not a number
+    """
+    if not isinstance(fahrenheit, (int, float)):
+        raise TypeError("Input must be a number")
+    
+    # Conversion formula: (°F - 32) × 5/9 = °C
+    celsius = (fahrenheit - 32) * 5/9
+    return round(celsius, 2)

--- a/tests/test_temperature_converter.py
+++ b/tests/test_temperature_converter.py
@@ -1,0 +1,27 @@
+import pytest
+from src.temperature_converter import fahrenheit_to_celsius
+
+def test_freezing_point():
+    """Test conversion of freezing point (32°F = 0°C)"""
+    assert fahrenheit_to_celsius(32) == 0
+
+def test_boiling_point():
+    """Test conversion of boiling point (212°F = 100°C)"""
+    assert fahrenheit_to_celsius(212) == 100
+
+def test_negative_temperature():
+    """Test conversion of a negative temperature"""
+    assert fahrenheit_to_celsius(-40) == -40
+
+def test_decimal_temperature():
+    """Test conversion of a decimal temperature"""
+    assert fahrenheit_to_celsius(98.6) == 37
+
+def test_invalid_input_type():
+    """Test that TypeError is raised for non-numeric input"""
+    with pytest.raises(TypeError):
+        fahrenheit_to_celsius("not a number")
+
+def test_rounding():
+    """Test rounding to 2 decimal places"""
+    assert fahrenheit_to_celsius(33.8) == 1.00


### PR DESCRIPTION
# Implement Fahrenheit to Celsius Temperature Conversion

## Task
Write a function to convert Fahrenheit to Celsius.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new utility function to convert temperatures from Fahrenheit to Celsius. The function takes a Fahrenheit temperature as input and returns the equivalent Celsius temperature using the standard conversion formula: (F - 32) * 5/9.

## Test Cases
 - Verifies the conversion of a standard temperature (e.g., 32°F to 0°C)
 - Checks conversion of negative Fahrenheit temperatures
 - Ensures the function handles decimal input temperatures accurately
 - Validates edge cases like freezing and boiling points of water