### PR TITLE
Add Colorful Logging Functionality

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+termcolor

--- a/src/colorful_logger.py
+++ b/src/colorful_logger.py
@@ -1,0 +1,23 @@
+from termcolor import colored
+
+def log_colored(message, color='green'):
+    """
+    Log a message in a specified color.
+    
+    Args:
+        message (str): The message to log
+        color (str, optional): Color of the message. 
+            Supported colors: 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'. 
+            Defaults to 'green'.
+    
+    Raises:
+        ValueError: If an unsupported color is provided
+    """
+    supported_colors = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white']
+    
+    if color not in supported_colors:
+        raise ValueError(f"Unsupported color. Choose from {supported_colors}")
+    
+    colored_message = colored(message, color)
+    print(colored_message)
+    return colored_message

--- a/tests/test_colorful_logger.py
+++ b/tests/test_colorful_logger.py
@@ -1,0 +1,27 @@
+import pytest
+from termcolor import colored
+from src.colorful_logger import log_colored
+
+def test_default_green_color(capsys):
+    """Test that default color is green"""
+    log_colored("Test message")
+    captured = capsys.readouterr()
+    assert colored("Test message", 'green') in captured.out
+
+def test_different_colors(capsys):
+    """Test logging with different supported colors"""
+    colors = ['red', 'yellow', 'blue', 'magenta', 'cyan', 'white']
+    for color in colors:
+        log_colored("Test message", color)
+        captured = capsys.readouterr()
+        assert colored("Test message", color) in captured.out
+
+def test_unsupported_color():
+    """Test that an unsupported color raises a ValueError"""
+    with pytest.raises(ValueError, match="Unsupported color"):
+        log_colored("Test message", "orange")
+
+def test_return_value():
+    """Test that the function returns the colored message"""
+    result = log_colored("Test message", "blue")
+    assert result == colored("Test message", "blue")


### PR DESCRIPTION
# Add Colorful Logging Functionality

## Task
Write a function to log a message in a different color.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Implemented a new logging utility that allows logging messages in different colors to improve console readability and distinguish between log types.

## Test Cases
 - Verify that the color logging function works with different color inputs
 - Ensure log messages are displayed correctly with various color options
 - Check that the logging function handles edge cases like invalid color inputs
 - Confirm that the colorful logging does not interfere with existing logging mechanisms