### PR TITLE
Implement File Read-Only Check Function

### DIFF
--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -1,0 +1,27 @@
+import os
+
+def is_file_read_only(file_path):
+    """
+    Determine if a file is read-only.
+    
+    Args:
+        file_path (str): Path to the file to check.
+    
+    Returns:
+        bool: True if the file is read-only, False otherwise.
+    
+    Raises:
+        FileNotFoundError: If the file does not exist.
+    """
+    # Validate file exists
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"File not found: {file_path}")
+    
+    # Check file permissions using os.access() with os.R_OK
+    is_readable = os.access(file_path, os.R_OK)
+    
+    # Check if the file has write permissions
+    is_writable = os.access(file_path, os.W_OK)
+    
+    # File is read-only if it's readable but not writable
+    return is_readable and not is_writable

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,0 +1,45 @@
+import os
+import pytest
+import tempfile
+import stat
+
+from src.file_utils import is_file_read_only
+
+def test_is_file_read_only_regular_file():
+    """Test regular writable file returns False."""
+    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as temp_file:
+        temp_file_path = temp_file.name
+        try:
+            assert is_file_read_only(temp_file_path) == False
+        finally:
+            os.unlink(temp_file_path)
+
+def test_is_file_read_only_true_case():
+    """Test a read-only file returns True."""
+    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as temp_file:
+        temp_file_path = temp_file.name
+        try:
+            # Make the file read-only
+            os.chmod(temp_file_path, stat.S_IRUSR)
+            
+            assert is_file_read_only(temp_file_path) == True
+        finally:
+            os.unlink(temp_file_path)
+
+def test_is_file_read_only_nonexistent_file():
+    """Test that FileNotFoundError is raised for nonexistent files."""
+    with pytest.raises(FileNotFoundError):
+        is_file_read_only('nonexistent_file.txt')
+
+def test_is_file_read_only_with_root_user_permissions():
+    """Test read-only status for system files that might be accessible by root."""
+    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as temp_file:
+        temp_file_path = temp_file.name
+        try:
+            # Making file readable only by root
+            os.chmod(temp_file_path, 0o400)
+            
+            # Check read-only status
+            assert is_file_read_only(temp_file_path) == True
+        finally:
+            os.unlink(temp_file_path)


### PR DESCRIPTION
# Implement File Read-Only Check Function

## Task
Write a function to determine if a file is read-only.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new utility function to check if a file is read-only using Python's os module. The function checks file permissions to determine read-only status.

## Test Cases
 - Verify function returns True for a read-only file
 - Verify function returns False for a writable file
 - Check function handles non-existent files gracefully
 - Ensure function works with different file permission scenarios