### PR TITLE
Implement Leap Year Validation Function

### DIFF
--- a/src/leap_year.py
+++ b/src/leap_year.py
@@ -1,0 +1,29 @@
+def is_leap_year(year):
+    """
+    Determine if a given year is a leap year.
+    
+    A leap year is defined as:
+    - A year divisible by 4
+    - Except years divisible by 100 are not leap years
+    - Unless they are also divisible by 400, then they are leap years
+    
+    Args:
+        year (int): The year to check
+    
+    Returns:
+        bool: True if the year is a leap year, False otherwise
+    
+    Raises:
+        TypeError: If the input is not an integer
+        ValueError: If the year is not a positive integer
+    """
+    # Check input type
+    if not isinstance(year, int):
+        raise TypeError("Year must be an integer")
+    
+    # Check year is positive
+    if year <= 0:
+        raise ValueError("Year must be a positive integer")
+    
+    # Leap year calculation
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)

--- a/tests/test_leap_year.py
+++ b/tests/test_leap_year.py
@@ -1,0 +1,37 @@
+import pytest
+from src.leap_year import is_leap_year
+
+def test_standard_leap_years():
+    """Test typical leap years"""
+    assert is_leap_year(2000) == True
+    assert is_leap_year(2004) == True
+    assert is_leap_year(2020) == True
+    assert is_leap_year(2024) == True
+
+def test_non_leap_years():
+    """Test typical non-leap years"""
+    assert is_leap_year(2100) == False
+    assert is_leap_year(2001) == False
+    assert is_leap_year(2023) == False
+    assert is_leap_year(1900) == False
+
+def test_century_exceptions():
+    """Test century years special cases"""
+    assert is_leap_year(2000) == True   # Divisible by 400
+    assert is_leap_year(1600) == True   # Divisible by 400
+    assert is_leap_year(1900) == False  # Divisible by 100 but not 400
+    assert is_leap_year(2100) == False  # Divisible by 100 but not 400
+
+def test_edge_invalid_inputs():
+    """Test error handling for invalid inputs"""
+    with pytest.raises(TypeError):
+        is_leap_year("2023")
+    
+    with pytest.raises(TypeError):
+        is_leap_year(2023.5)
+    
+    with pytest.raises(ValueError):
+        is_leap_year(0)
+    
+    with pytest.raises(ValueError):
+        is_leap_year(-2023)


### PR DESCRIPTION
# Implement Leap Year Validation Function

## Task
Write a function to determine if a given year is a leap year.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new function to validate leap years based on standard leap year rules:
1. A year divisible by 4 is a leap year
2. Exception: Century years (divisible by 100) are not leap years
3. Exception to the exception: Century years divisible by 400 are leap years

## Test Cases
 - Verifies a typical leap year (divisible by 4)
 - Checks that century years are not leap years
 - Confirms century years divisible by 400 are leap years
 - Validates edge cases like years divisible by 100 but not 400
 - Ensures function correctly handles negative and zero input years