### PR TITLE
Implement Leap Year Validation Function

### DIFF
--- a/src/leap_year.py
+++ b/src/leap_year.py
@@ -1,0 +1,29 @@
+def is_leap_year(year):
+    """
+    Determine if a given year is a leap year.
+    
+    A year is a leap year if:
+    - It is divisible by 4
+    - But if it's also divisible by 100, it is NOT a leap year
+    - Unless it is also divisible by 400, then it IS a leap year
+    
+    Args:
+        year (int): The year to check
+    
+    Returns:
+        bool: True if the year is a leap year, False otherwise
+    
+    Raises:
+        TypeError: If the input is not an integer
+        ValueError: If the input is not a positive year
+    """
+    # Check input type
+    if not isinstance(year, int):
+        raise TypeError("Year must be an integer")
+    
+    # Check positive year
+    if year <= 0:
+        raise ValueError("Year must be a positive integer")
+    
+    # Leap year calculation logic
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)

--- a/tests/test_leap_year.py
+++ b/tests/test_leap_year.py
@@ -1,0 +1,38 @@
+import pytest
+from src.leap_year import is_leap_year
+
+def test_typical_leap_years():
+    """Test typical leap years divisible by 4"""
+    assert is_leap_year(2020) == True
+    assert is_leap_year(2024) == True
+    assert is_leap_year(2000) == True
+
+def test_non_leap_years():
+    """Test years that are not leap years"""
+    assert is_leap_year(2021) == False
+    assert is_leap_year(2022) == False
+    assert is_leap_year(2023) == False
+
+def test_century_years():
+    """Test century years that are not leap years"""
+    assert is_leap_year(1900) == False
+    assert is_leap_year(2100) == False
+
+def test_special_century_years():
+    """Test century years divisible by 400"""
+    assert is_leap_year(2000) == True
+    assert is_leap_year(2400) == True
+
+def test_invalid_inputs():
+    """Test error handling for invalid inputs"""
+    with pytest.raises(TypeError):
+        is_leap_year("2020")
+    
+    with pytest.raises(TypeError):
+        is_leap_year(3.14)
+    
+    with pytest.raises(ValueError):
+        is_leap_year(0)
+    
+    with pytest.raises(ValueError):
+        is_leap_year(-2020)


### PR DESCRIPTION
# Implement Leap Year Validation Function

## Task
Write a function to determine if a given year is a leap year.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a robust leap year validation function that handles various edge cases for determining if a given year is a leap year. The implementation follows the standard leap year rules:
- Years divisible by 4 are leap years
- Except years divisible by 100 are not leap years
- Unless they are also divisible by 400, which are leap years

## Test Cases
 - Verifies a standard leap year is correctly identified
 - Confirms century years are not leap years
 - Checks that century years divisible by 400 are leap years
 - Ensures negative years are handled correctly
 - Validates zero is not a leap year
 - Checks boundary conditions for leap year calculations