### PR TITLE
Implement Day Name Retrieval Function

### DIFF
--- a/src/day_of_week.py
+++ b/src/day_of_week.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+def get_day_of_week(date_str):
+    """
+    Return the name of the day for a given date.
+    
+    Args:
+        date_str (str): Date in format 'YYYY-MM-DD'
+    
+    Returns:
+        str: Name of the day of the week
+    
+    Raises:
+        ValueError: If the date is not in the correct format
+    """
+    try:
+        # Parse the date string
+        date_obj = datetime.strptime(date_str, '%Y-%m-%d')
+        
+        # Return the day name (full name)
+        return date_obj.strftime('%A')
+    
+    except ValueError:
+        # Raise a descriptive error for invalid date format
+        raise ValueError(f"Invalid date format. Please use 'YYYY-MM-DD'. Got: {date_str}")

--- a/tests/test_day_of_week.py
+++ b/tests/test_day_of_week.py
@@ -1,0 +1,38 @@
+import pytest
+from src.day_of_week import get_day_of_week
+
+def test_valid_dates():
+    # Test various known dates and their expected day names
+    test_cases = [
+        ('2023-06-22', 'Thursday'),   # A specific known date
+        ('2024-02-14', 'Wednesday'),  # Valentine's Day
+        ('2000-01-01', 'Saturday'),   # Millennium start
+    ]
+    
+    for date, expected_day in test_cases:
+        assert get_day_of_week(date) == expected_day, f"Failed for date {date}"
+
+def test_invalid_date_format():
+    # Test various invalid date formats
+    invalid_dates = [
+        '22-06-2023',        # Wrong order
+        '2023/06/22',        # Wrong separator
+        '2023-6-2',          # Single digit month/day
+        '2023-13-32',        # Invalid month/day
+        '',                  # Empty string
+    ]
+    
+    for invalid_date in invalid_dates:
+        with pytest.raises(ValueError, match="Invalid date format"):
+            get_day_of_week(invalid_date)
+
+def test_edge_cases():
+    # Test edge cases like leap years
+    edge_cases = [
+        ('2020-02-29', 'Saturday'),   # Leap year date
+        ('2023-12-31', 'Sunday'),     # Last day of the year
+        ('2024-01-01', 'Monday')      # First day of the year
+    ]
+    
+    for date, expected_day in edge_cases:
+        assert get_day_of_week(date) == expected_day, f"Failed for edge case {date}"


### PR DESCRIPTION
# Implement Day Name Retrieval Function

## Task
Write a function to return the name of the day for a given date.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new function to convert a given date into its corresponding day name (e.g., Monday, Tuesday, etc.). The function takes a date as input and returns the full name of the day of the week.

## Test Cases
 - Verify the function returns correct day name for a past date
 - Confirm the function handles leap year dates correctly
 - Ensure the function works with dates from different years
 - Check that the function returns full day names (e.g., 'Monday', not 'Mon')