### PR TITLE
Implement Weekend Counting Function for Months

### DIFF
--- a/src/weekend_counter.py
+++ b/src/weekend_counter.py
@@ -1,0 +1,35 @@
+import calendar
+from datetime import date, timedelta
+
+def count_weekends_in_month(year: int, month: int) -> int:
+    """
+    Count the number of weekend days (Saturdays and Sundays) in a given month.
+    
+    Args:
+        year (int): The year to check
+        month (int): The month to check (1-12)
+    
+    Returns:
+        int: Number of weekend days in the specified month
+    
+    Raises:
+        ValueError: If year or month is invalid
+    """
+    # Validate input
+    if not (1 <= month <= 12):
+        raise ValueError("Month must be between 1 and 12")
+    
+    if year < 1:
+        raise ValueError("Year must be a positive integer")
+    
+    # Get the number of days in the month
+    _, num_days = calendar.monthrange(year, month)
+    
+    # Count weekends
+    weekend_count = 0
+    for day in range(1, num_days + 1):
+        current_date = date(year, month, day)
+        if current_date.weekday() in [5, 6]:  # 5 = Saturday, 6 = Sunday
+            weekend_count += 1
+    
+    return weekend_count

--- a/tests/test_weekend_counter.py
+++ b/tests/test_weekend_counter.py
@@ -1,0 +1,35 @@
+import pytest
+from src.weekend_counter import count_weekends_in_month
+
+def test_count_weekends_in_typical_month():
+    # January 2023 has 5 weekend days
+    assert count_weekends_in_month(2023, 1) == 10
+
+def test_count_weekends_in_february():
+    # February 2023 has 4 weekend days
+    assert count_weekends_in_month(2023, 2) == 8
+
+def test_count_weekends_in_leap_year_february():
+    # February 2024 (leap year) has different number of days
+    assert count_weekends_in_month(2024, 2) == 10
+
+def test_invalid_month_low():
+    with pytest.raises(ValueError, match="Month must be between 1 and 12"):
+        count_weekends_in_month(2023, 0)
+
+def test_invalid_month_high():
+    with pytest.raises(ValueError, match="Month must be between 1 and 12"):
+        count_weekends_in_month(2023, 13)
+
+def test_invalid_year():
+    with pytest.raises(ValueError, match="Year must be a positive integer"):
+        count_weekends_in_month(0, 6)
+
+def test_different_years():
+    # Different years with same month can have different weekend counts
+    assert count_weekends_in_month(2022, 12) != count_weekends_in_month(2023, 12)
+
+def test_edge_cases():
+    # Specific edge case years and months
+    assert count_weekends_in_month(2020, 12) == 10  # December 2020
+    assert count_weekends_in_month(2021, 1) == 10   # January 2021


### PR DESCRIPTION
# Implement Weekend Counting Function for Months

## Task
Write a function to determine the number of weekends in a given month.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new utility function to calculate the number of weekends in a specific month. The function takes a month and year as input and returns the total number of weekend days (Saturdays and Sundays) in that month.

## Test Cases
 - Verify the function correctly counts weekends for a month with 4 full weekends
 - Check weekend counting for months with partial weekends at the start or end
 - Ensure function works for leap years and different month lengths
 - Validate weekend count for edge cases like February in different years
 - Test function with various input years and months