### PR TITLE
Add Fahrenheit to Celsius Conversion Function

### DIFF
--- a/src/temperature_conversion.py
+++ b/src/temperature_conversion.py
@@ -1,0 +1,18 @@
+def fahrenheit_to_celsius(fahrenheit):
+    """
+    Convert temperature from Fahrenheit to Celsius.
+    
+    Args:
+        fahrenheit (float): Temperature in Fahrenheit
+    
+    Returns:
+        float: Temperature in Celsius
+    
+    Raises:
+        TypeError: If input is not a number
+    """
+    if not isinstance(fahrenheit, (int, float)):
+        raise TypeError("Input must be a number")
+    
+    celsius = (fahrenheit - 32) * 5/9
+    return round(celsius, 2)

--- a/tests/test_temperature_conversion.py
+++ b/tests/test_temperature_conversion.py
@@ -1,0 +1,27 @@
+import pytest
+from src.temperature_conversion import fahrenheit_to_celsius
+
+def test_freezing_point():
+    """Test conversion of 32°F to 0°C"""
+    assert fahrenheit_to_celsius(32) == 0
+
+def test_boiling_point():
+    """Test conversion of 212°F to 100°C"""
+    assert fahrenheit_to_celsius(212) == 100
+
+def test_negative_temperature():
+    """Test conversion of a negative temperature"""
+    assert fahrenheit_to_celsius(-40) == -40
+
+def test_decimal_temperature():
+    """Test conversion of a decimal temperature"""
+    assert fahrenheit_to_celsius(98.6) == 37
+
+def test_invalid_input_type():
+    """Test that TypeError is raised for non-numeric input"""
+    with pytest.raises(TypeError):
+        fahrenheit_to_celsius("not a number")
+
+def test_large_number():
+    """Test conversion of a large temperature value"""
+    assert fahrenheit_to_celsius(1000) == 537.78


### PR DESCRIPTION
# Add Fahrenheit to Celsius Conversion Function

## Task
Write a function to convert Fahrenheit to Celsius.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Implemented a new utility function to convert temperatures from Fahrenheit to Celsius. The function takes a Fahrenheit temperature as input and returns its equivalent in Celsius using the standard conversion formula: (°F - 32) * 5/9.

## Test Cases
 - Verify the conversion function correctly transforms 32°F to 0°C
 - Ensure the function handles negative Fahrenheit temperatures accurately
 - Check that the conversion works with decimal input values
 - Validate the function returns the correct Celsius temperature for various Fahrenheit inputs