### PR TITLE
Add Celsius to Fahrenheit Conversion Function

### DIFF
--- a/src/temperature_converter.py
+++ b/src/temperature_converter.py
@@ -1,0 +1,18 @@
+def celsius_to_fahrenheit(celsius: float) -> float:
+    """
+    Convert a temperature from Celsius to Fahrenheit.
+    
+    Args:
+        celsius (float): Temperature in Celsius degrees
+    
+    Returns:
+        float: Temperature converted to Fahrenheit
+    
+    Raises:
+        TypeError: If input is not a number
+    """
+    if not isinstance(celsius, (int, float)):
+        raise TypeError("Input must be a number")
+    
+    fahrenheit = (celsius * 9/5) + 32
+    return fahrenheit

--- a/tests/test_temperature_converter.py
+++ b/tests/test_temperature_converter.py
@@ -1,0 +1,16 @@
+import pytest
+from src.temperature_converter import celsius_to_fahrenheit
+
+def test_celsius_to_fahrenheit_positive():
+    assert celsius_to_fahrenheit(0) == 32
+    assert celsius_to_fahrenheit(100) == 212
+    assert celsius_to_fahrenheit(-40) == -40
+
+def test_celsius_to_fahrenheit_float():
+    assert round(celsius_to_fahrenheit(37.5), 1) == 99.5
+
+def test_celsius_to_fahrenheit_type_error():
+    with pytest.raises(TypeError):
+        celsius_to_fahrenheit("not a number")
+    with pytest.raises(TypeError):
+        celsius_to_fahrenheit(None)


### PR DESCRIPTION
# Add Celsius to Fahrenheit Conversion Function

## Task
Write a function to convert Celsius to Fahrenheit.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Implemented a new utility function to convert temperatures from Celsius to Fahrenheit. The function takes a Celsius temperature as input and returns the equivalent Fahrenheit temperature using the standard conversion formula (F = C * 9/5 + 32).

## Test Cases
 - Verify the function correctly converts 0°C to 32°F
 - Ensure the function handles negative temperatures accurately
 - Check that the function returns a precise floating-point conversion
 - Validate the function works with decimal input temperatures