### PR TITLE
Implement Celsius to Fahrenheit Conversion Function

### DIFF
--- a/src/temperature_converter.py
+++ b/src/temperature_converter.py
@@ -1,0 +1,17 @@
+def celsius_to_fahrenheit(celsius):
+    """
+    Convert temperature from Celsius to Fahrenheit.
+    
+    Args:
+        celsius (float): Temperature in Celsius to convert.
+    
+    Returns:
+        float: Temperature converted to Fahrenheit.
+    
+    Raises:
+        TypeError: If input is not a number.
+    """
+    if not isinstance(celsius, (int, float)):
+        raise TypeError("Input must be a number")
+    
+    return (celsius * 9/5) + 32

--- a/tests/test_temperature_converter.py
+++ b/tests/test_temperature_converter.py
@@ -1,0 +1,25 @@
+import pytest
+from src.temperature_converter import celsius_to_fahrenheit
+
+def test_freezing_point():
+    """Test conversion of 0°C to 32°F"""
+    assert celsius_to_fahrenheit(0) == 32
+
+def test_boiling_point():
+    """Test conversion of 100°C to 212°F"""
+    assert celsius_to_fahrenheit(100) == 212
+
+def test_negative_temperature():
+    """Test conversion of a negative temperature"""
+    assert celsius_to_fahrenheit(-40) == -40
+
+def test_decimal_temperature():
+    """Test conversion of a decimal temperature"""
+    assert round(celsius_to_fahrenheit(37.5), 1) == 99.5
+
+def test_invalid_input_type():
+    """Test that a TypeError is raised for non-numeric inputs"""
+    with pytest.raises(TypeError):
+        celsius_to_fahrenheit("not a number")
+    with pytest.raises(TypeError):
+        celsius_to_fahrenheit(None)


### PR DESCRIPTION
# Implement Celsius to Fahrenheit Conversion Function

## Task
Write a function to convert Celsius to Fahrenheit.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new utility function to convert temperatures from Celsius to Fahrenheit. The function uses the standard conversion formula: (°C × 9/5) + 32 = °F. Implemented with proper error handling and type checking.

## Test Cases
 - Verifies the function correctly converts 0°C to 32°F
 - Checks conversion of negative temperatures
 - Ensures the function handles floating-point inputs
 - Validates error handling for invalid input types