### PR TITLE
Implement Leap Year Checker Function

### DIFF
--- a/src/leap_year.py
+++ b/src/leap_year.py
@@ -1,0 +1,29 @@
+def is_leap_year(year):
+    """
+    Determine if a given year is a leap year.
+    
+    A leap year is divisible by 4, except for century years (years ending with 00).
+    Century years are leap years only if they are perfectly divisible by 400.
+    
+    Args:
+        year (int): The year to check.
+    
+    Returns:
+        bool: True if the year is a leap year, False otherwise.
+    
+    Raises:
+        TypeError: If the input is not an integer.
+        ValueError: If the input year is not a positive integer.
+    """
+    # Check if input is an integer
+    if not isinstance(year, int):
+        raise TypeError("Year must be an integer")
+    
+    # Check if year is positive
+    if year <= 0:
+        raise ValueError("Year must be a positive integer")
+    
+    # Leap year rules:
+    # 1. Divisible by 4
+    # 2. Not divisible by 100 unless divisible by 400
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)

--- a/tests/test_leap_year.py
+++ b/tests/test_leap_year.py
@@ -1,0 +1,43 @@
+import pytest
+from src.leap_year import is_leap_year
+
+def test_typical_leap_years():
+    # Years divisible by 4 but not 100 are leap years
+    assert is_leap_year(2020) == True
+    assert is_leap_year(2024) == True
+    assert is_leap_year(2028) == True
+
+def test_non_leap_years():
+    # Years not divisible by 4 are not leap years
+    assert is_leap_year(2021) == False
+    assert is_leap_year(2023) == False
+    assert is_leap_year(2025) == False
+
+def test_century_years():
+    # Century years (divisible by 100) are not leap years, except those divisible by 400
+    assert is_leap_year(1900) == False  # Not divisible by 400
+    assert is_leap_year(2000) == True   # Divisible by 400
+    assert is_leap_year(2100) == False  # Not divisible by 400
+
+def test_early_leap_years():
+    # Check some historical leap years
+    assert is_leap_year(1600) == True
+    assert is_leap_year(1804) == True
+
+def test_edge_cases():
+    # Minimum year
+    assert is_leap_year(4) == True
+
+def test_invalid_inputs():
+    # Test type and value errors
+    with pytest.raises(TypeError):
+        is_leap_year("2020")
+    
+    with pytest.raises(TypeError):
+        is_leap_year(2020.5)
+    
+    with pytest.raises(ValueError):
+        is_leap_year(0)
+    
+    with pytest.raises(ValueError):
+        is_leap_year(-2020)


### PR DESCRIPTION
# Implement Leap Year Checker Function

## Task
Write a function to determine if a given year is a leap year.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new function to check if a given year is a leap year. The implementation follows the standard leap year rules:
- A year is a leap year if it is divisible by 4
- Except if it's also divisible by 100, it is not a leap year
- Unless it is also divisible by 400, then it is a leap year

## Test Cases
 - Verify that years divisible by 4 are leap years
 - Confirm that years divisible by 100 are not leap years
 - Ensure years divisible by 400 are leap years
 - Check edge cases like 2000 and 2100
 - Test with a range of years including current, past, and future years