### PR TITLE
Implement Leap Year Determination Function

### DIFF
--- a/src/leap_year.py
+++ b/src/leap_year.py
@@ -1,0 +1,28 @@
+def is_leap_year(year):
+    """
+    Determine if a given year is a leap year.
+    
+    A leap year is defined as:
+    - A year divisible by 4
+    - Except if it's divisible by 100, it must also be divisible by 400
+    
+    Args:
+        year (int): The year to check
+    
+    Returns:
+        bool: True if the year is a leap year, False otherwise
+    
+    Raises:
+        TypeError: If the input is not an integer
+        ValueError: If the input is not a positive integer
+    """
+    # Check if input is an integer
+    if not isinstance(year, int):
+        raise TypeError("Year must be an integer")
+    
+    # Check if year is positive
+    if year <= 0:
+        raise ValueError("Year must be a positive integer")
+    
+    # Leap year conditions
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)

--- a/tests/test_leap_year.py
+++ b/tests/test_leap_year.py
@@ -1,0 +1,40 @@
+import pytest
+from src.leap_year import is_leap_year
+
+def test_standard_leap_years():
+    """Test standard leap years divisible by 4"""
+    assert is_leap_year(2020) == True
+    assert is_leap_year(2024) == True
+    assert is_leap_year(2000) == True
+
+def test_non_leap_years():
+    """Test non-leap years"""
+    assert is_leap_year(2100) == False
+    assert is_leap_year(2001) == False
+    assert is_leap_year(2022) == False
+
+def test_century_years():
+    """Test century years that are leap years"""
+    assert is_leap_year(2000) == True
+    assert is_leap_year(2400) == True
+
+def test_century_years_not_leap():
+    """Test century years that are not leap years"""
+    assert is_leap_year(1900) == False
+    assert is_leap_year(2100) == False
+
+def test_invalid_input_types():
+    """Test handling of invalid input types"""
+    with pytest.raises(TypeError):
+        is_leap_year("2020")
+    with pytest.raises(TypeError):
+        is_leap_year(2020.5)
+    with pytest.raises(TypeError):
+        is_leap_year(None)
+
+def test_invalid_year_values():
+    """Test handling of invalid year values"""
+    with pytest.raises(ValueError):
+        is_leap_year(0)
+    with pytest.raises(ValueError):
+        is_leap_year(-2020)


### PR DESCRIPTION
# Implement Leap Year Determination Function

## Task
Write a function to determine if a given year is a leap year.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new function to check if a given year is a leap year. The implementation follows the standard leap year rules:
- A year is a leap year if it is divisible by 4
- Except if it's divisible by 100, it is not a leap year
- Unless it is also divisible by 400, then it is a leap year

## Test Cases
 - Verifies a standard leap year (divisible by 4)
 - Checks that years divisible by 100 are not leap years
 - Confirms years divisible by 400 are leap years
 - Validates edge cases like 2000 and 1900
 - Ensures function works with a range of input years