### PR TITLE
Implement Weekend Count Function for Month

### DIFF
--- a/src/weekend_counter.py
+++ b/src/weekend_counter.py
@@ -1,0 +1,35 @@
+import calendar
+from datetime import date
+
+def count_weekends_in_month(year: int, month: int) -> int:
+    """
+    Determine the number of weekend days (Saturdays and Sundays) in a given month.
+    
+    Args:
+        year (int): The year (e.g., 2023)
+        month (int): The month (1-12)
+    
+    Returns:
+        int: Number of weekend days in the specified month
+    
+    Raises:
+        ValueError: If year or month is invalid
+    """
+    # Validate input
+    if not (1 <= month <= 12):
+        raise ValueError("Month must be between 1 and 12")
+    
+    if year < 1:
+        raise ValueError("Year must be a positive integer")
+    
+    # Get the number of days in the month
+    _, num_days = calendar.monthrange(year, month)
+    
+    # Count weekend days
+    weekend_count = 0
+    for day in range(1, num_days + 1):
+        current_date = date(year, month, day)
+        if current_date.weekday() in [5, 6]:  # 5 is Saturday, 6 is Sunday
+            weekend_count += 1
+    
+    return weekend_count

--- a/tests/test_weekend_counter.py
+++ b/tests/test_weekend_counter.py
@@ -1,0 +1,40 @@
+import pytest
+from src.weekend_counter import count_weekends_in_month
+
+def test_count_weekends_standard_month():
+    # Test a month with full 4 weekends (July 2023)
+    assert count_weekends_in_month(2023, 7) == 10
+
+def test_count_weekends_february():
+    # Test a month with fewer days (February 2023)
+    assert count_weekends_in_month(2023, 2) == 8
+
+def test_count_weekends_leap_year():
+    # Test a leap year February 
+    assert count_weekends_in_month(2024, 2) == 9
+
+def test_invalid_month_low():
+    # Test handling of invalid low month
+    with pytest.raises(ValueError, match="Month must be between 1 and 12"):
+        count_weekends_in_month(2023, 0)
+
+def test_invalid_month_high():
+    # Test handling of invalid high month
+    with pytest.raises(ValueError, match="Month must be between 1 and 12"):
+        count_weekends_in_month(2023, 13)
+
+def test_invalid_year():
+    # Test handling of invalid year
+    with pytest.raises(ValueError, match="Year must be a positive integer"):
+        count_weekends_in_month(0, 5)
+
+def test_various_years_months():
+    # Additional test cases for different years and months
+    test_cases = [
+        (2023, 1, 8),   # January
+        (2023, 12, 10), # December
+        (2024, 3, 9),   # March in a leap year
+    ]
+    
+    for year, month, expected_weekends in test_cases:
+        assert count_weekends_in_month(year, month) == expected_weekends

--- a/tests/test_weekend_counter.py
+++ b/tests/test_weekend_counter.py
@@ -11,7 +11,7 @@ def test_count_weekends_february():
 
 def test_count_weekends_leap_year():
     # Test a leap year February 
-    assert count_weekends_in_month(2024, 2) == 9
+    assert count_weekends_in_month(2024, 2) == 8
 
 def test_invalid_month_low():
     # Test handling of invalid low month

--- a/tests/test_weekend_counter.py
+++ b/tests/test_weekend_counter.py
@@ -33,7 +33,7 @@ def test_various_years_months():
     test_cases = [
         (2023, 1, 9),   # January
         (2023, 12, 10), # December
-        (2024, 3, 9),   # March in a leap year
+        (2024, 3, 10),   # March in a leap year
     ]
     
     for year, month, expected_weekends in test_cases:

--- a/tests/test_weekend_counter.py
+++ b/tests/test_weekend_counter.py
@@ -31,7 +31,7 @@ def test_invalid_year():
 def test_various_years_months():
     # Additional test cases for different years and months
     test_cases = [
-        (2023, 1, 8),   # January
+        (2023, 1, 9),   # January
         (2023, 12, 10), # December
         (2024, 3, 9),   # March in a leap year
     ]


### PR DESCRIPTION
# Implement Weekend Count Function for Month

## Task
Write a function to determine the number of weekends in a given month.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new utility function to calculate the number of weekend days (Saturdays and Sundays) in a specific month. The function takes a month and year as input and returns the total count of weekend days.

## Test Cases
 - Verifies the function correctly counts weekends for a month with 4 full weekends
 - Checks weekend count for a month starting or ending mid-week
 - Ensures correct weekend calculation for leap years
 - Validates weekend counting across different months with varying weekend distributions