### PR TITLE
Implement Celsius to Fahrenheit Conversion Function

### DIFF
--- a/src/temperature_converter.py
+++ b/src/temperature_converter.py
@@ -1,0 +1,17 @@
+def celsius_to_fahrenheit(celsius):
+    """
+    Convert Celsius temperature to Fahrenheit.
+    
+    Args:
+        celsius (float): Temperature in Celsius degrees
+    
+    Returns:
+        float: Temperature converted to Fahrenheit
+    
+    Raises:
+        TypeError: If input is not a number
+    """
+    if not isinstance(celsius, (int, float)):
+        raise TypeError("Input must be a numeric value")
+    
+    return (celsius * 9/5) + 32

--- a/tests/test_temperature_converter.py
+++ b/tests/test_temperature_converter.py
@@ -1,0 +1,26 @@
+import pytest
+from src.temperature_converter import celsius_to_fahrenheit
+
+def test_celsius_to_fahrenheit_positive():
+    """Test conversion of a positive Celsius temperature"""
+    assert celsius_to_fahrenheit(0) == 32.0
+    assert celsius_to_fahrenheit(100) == 212.0
+    assert celsius_to_fahrenheit(37) == 98.6
+
+def test_celsius_to_fahrenheit_negative():
+    """Test conversion of a negative Celsius temperature"""
+    assert celsius_to_fahrenheit(-40) == -40.0
+    assert celsius_to_fahrenheit(-273.15) == -459.67
+
+def test_celsius_to_fahrenheit_decimal():
+    """Test conversion of decimal temperatures"""
+    assert round(celsius_to_fahrenheit(25.5), 2) == 77.9
+
+def test_celsius_to_fahrenheit_invalid_input():
+    """Test that invalid input raises a TypeError"""
+    with pytest.raises(TypeError):
+        celsius_to_fahrenheit("not a number")
+    with pytest.raises(TypeError):
+        celsius_to_fahrenheit(None)
+    with pytest.raises(TypeError):
+        celsius_to_fahrenheit([])


### PR DESCRIPTION
# Implement Celsius to Fahrenheit Conversion Function

## Task
Write a function to convert Celsius to Fahrenheit.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new utility function to convert temperatures from Celsius to Fahrenheit. The function follows the standard conversion formula (°F = (°C × 9/5) + 32) and includes basic error handling.

## Test Cases
 - Verifies the conversion of 0°C to 32°F
 - Checks conversion of a positive temperature
 - Ensures conversion of a negative temperature
 - Validates handling of decimal temperature values
 - Confirms the function returns the correct Fahrenheit temperature