### PR TITLE
Implement Celsius to Fahrenheit Conversion Function

### DIFF
--- a/src/temperature_converter.py
+++ b/src/temperature_converter.py
@@ -1,0 +1,17 @@
+def celsius_to_fahrenheit(celsius):
+    """
+    Convert Celsius temperature to Fahrenheit.
+    
+    Args:
+        celsius (float): Temperature in Celsius
+    
+    Returns:
+        float: Temperature converted to Fahrenheit
+    
+    Raises:
+        TypeError: If input is not a number
+    """
+    if not isinstance(celsius, (int, float)):
+        raise TypeError("Input must be a number")
+    
+    return (celsius * 9/5) + 32

--- a/tests/test_temperature_converter.py
+++ b/tests/test_temperature_converter.py
@@ -1,0 +1,28 @@
+import pytest
+from src.temperature_converter import celsius_to_fahrenheit
+
+def test_freezing_point():
+    """Test conversion of 0°C to 32°F"""
+    assert celsius_to_fahrenheit(0) == 32
+
+def test_boiling_point():
+    """Test conversion of 100°C to 212°F"""
+    assert celsius_to_fahrenheit(100) == 212
+
+def test_negative_temperature():
+    """Test conversion of a negative temperature"""
+    assert celsius_to_fahrenheit(-40) == -40
+
+def test_float_input():
+    """Test conversion with float input"""
+    assert round(celsius_to_fahrenheit(37.5), 1) == 99.5
+
+def test_invalid_input_type():
+    """Test that TypeError is raised for non-numeric input"""
+    with pytest.raises(TypeError):
+        celsius_to_fahrenheit("not a number")
+
+def test_invalid_input_list():
+    """Test that TypeError is raised for list input"""
+    with pytest.raises(TypeError):
+        celsius_to_fahrenheit([10, 20])


### PR DESCRIPTION
# Implement Celsius to Fahrenheit Conversion Function

## Task
Write a function to convert Celsius to Fahrenheit.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new utility function to convert temperatures from Celsius to Fahrenheit. The function takes a Celsius temperature as input and returns the equivalent Fahrenheit temperature using the standard conversion formula (F = C * 9/5 + 32).

## Test Cases
 - Verifies that the conversion function correctly transforms 0°C to 32°F
 - Checks the conversion of a negative temperature from Celsius to Fahrenheit
 - Ensures the function handles decimal temperature inputs accurately
 - Validates the conversion of a positive temperature from Celsius to Fahrenheit