### PR TITLE
Implement Fahrenheit to Celsius Temperature Conversion

### DIFF
--- a/src/temperature_converter.py
+++ b/src/temperature_converter.py
@@ -1,0 +1,18 @@
+def fahrenheit_to_celsius(fahrenheit):
+    """
+    Convert temperature from Fahrenheit to Celsius.
+    
+    Args:
+        fahrenheit (float): Temperature in Fahrenheit
+    
+    Returns:
+        float: Temperature in Celsius, rounded to 2 decimal places
+    
+    Raises:
+        TypeError: If input is not a number
+    """
+    if not isinstance(fahrenheit, (int, float)):
+        raise TypeError("Input must be a number")
+    
+    celsius = (fahrenheit - 32) * 5/9
+    return round(celsius, 2)

--- a/tests/test_temperature_converter.py
+++ b/tests/test_temperature_converter.py
@@ -1,0 +1,24 @@
+import pytest
+from src.temperature_converter import fahrenheit_to_celsius
+
+def test_known_conversions():
+    """Test known Fahrenheit to Celsius conversions"""
+    assert fahrenheit_to_celsius(32) == 0
+    assert fahrenheit_to_celsius(212) == 100
+    assert fahrenheit_to_celsius(98.6) == 37
+
+def test_negative_temperatures():
+    """Test negative temperature conversions"""
+    assert fahrenheit_to_celsius(-40) == -40
+    assert fahrenheit_to_celsius(-32) == 0
+
+def test_float_input():
+    """Test floating point conversions"""
+    assert fahrenheit_to_celsius(68.5) == 20.28
+
+def test_invalid_input_type():
+    """Test input type validation"""
+    with pytest.raises(TypeError):
+        fahrenheit_to_celsius("not a number")
+    with pytest.raises(TypeError):
+        fahrenheit_to_celsius(None)

--- a/tests/test_temperature_converter.py
+++ b/tests/test_temperature_converter.py
@@ -10,7 +10,7 @@ def test_known_conversions():
 def test_negative_temperatures():
     """Test negative temperature conversions"""
     assert fahrenheit_to_celsius(-40) == -40
-    assert fahrenheit_to_celsius(-32) == 0
+    assert fahrenheit_to_celsius(-32) == -35.56
 
 def test_float_input():
     """Test floating point conversions"""


### PR DESCRIPTION
# Implement Fahrenheit to Celsius Temperature Conversion

## Task
Write a function to convert Fahrenheit to Celsius.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new utility function to convert temperatures from Fahrenheit to Celsius. The function takes a Fahrenheit temperature as input and returns the equivalent Celsius temperature using the standard conversion formula: (F - 32) * 5/9.

## Test Cases
 - Verify that the conversion function correctly converts 32°F to 0°C
 - Ensure the function handles freezing point conversion accurately
 - Check conversion of a negative Fahrenheit temperature to Celsius
 - Test conversion of a high temperature from Fahrenheit to Celsius
 - Validate that the function returns a precise floating-point Celsius temperature