### PR TITLE
Implement Weekend Counting Function for Months

### DIFF
--- a/src/weekend_counter.py
+++ b/src/weekend_counter.py
@@ -1,0 +1,32 @@
+import calendar
+from datetime import date, timedelta
+
+def count_weekends_in_month(year: int, month: int) -> int:
+    """
+    Count the number of weekend days (Saturdays and Sundays) in a given month.
+    
+    Args:
+        year (int): The year (e.g., 2023)
+        month (int): The month (1-12)
+    
+    Returns:
+        int: Number of weekend days in the specified month
+    
+    Raises:
+        ValueError: If year or month is invalid
+    """
+    # Validate input
+    if not (1 <= month <= 12):
+        raise ValueError("Month must be between 1 and 12")
+    
+    # Get the number of days in the month
+    _, num_days = calendar.monthrange(year, month)
+    
+    # Count weekend days
+    weekend_count = 0
+    for day in range(1, num_days + 1):
+        current_date = date(year, month, day)
+        if current_date.weekday() >= 5:  # 5 = Saturday, 6 = Sunday
+            weekend_count += 1
+    
+    return weekend_count

--- a/tests/test_weekend_counter.py
+++ b/tests/test_weekend_counter.py
@@ -1,0 +1,29 @@
+import pytest
+from src.weekend_counter import count_weekends_in_month
+
+def test_normal_month():
+    # Test a typical month (e.g., May 2023)
+    assert count_weekends_in_month(2023, 5) == 10
+
+def test_month_with_4_full_weekends():
+    # December 2023 has exactly 4 full weekends
+    assert count_weekends_in_month(2023, 12) == 8
+
+def test_leap_year_february():
+    # Test a leap year February
+    assert count_weekends_in_month(2020, 2) == 8
+
+def test_invalid_month_low():
+    # Test invalid month (too low)
+    with pytest.raises(ValueError):
+        count_weekends_in_month(2023, 0)
+
+def test_invalid_month_high():
+    # Test invalid month (too high)
+    with pytest.raises(ValueError):
+        count_weekends_in_month(2023, 13)
+
+def test_different_years():
+    # Test different years have different weekend counts
+    assert count_weekends_in_month(2023, 1) == 8
+    assert count_weekends_in_month(2024, 1) == 9  # Different due to leap year


### PR DESCRIPTION
# Implement Weekend Counting Function for Months

## Task
Write a function to determine the number of weekends in a given month.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new utility function to calculate the number of weekends in a specified month. The function takes a month and year as input and returns the total number of weekend days (Saturdays and Sundays) in that month.

## Test Cases
 - Verify the function returns correct number of weekends for a month with 31 days
 - Verify the function returns correct number of weekends for a month with 30 days
 - Verify the function handles February in leap years correctly
 - Verify the function handles different year inputs
 - Ensure the function works with edge cases like January and December