### PR TITLE
Implement Selective Multiple Filtering Function

### DIFF
--- a/src/filter_multiples.py
+++ b/src/filter_multiples.py
@@ -1,0 +1,17 @@
+def filter_special_multiples(numbers):
+    """
+    Filter a list of integers to return numbers that are multiples of either 3 or 5, but not both.
+    
+    Args:
+        numbers (list): A list of integers to filter
+    
+    Returns:
+        list: Sorted list of integers that are multiples of 3 or 5, but not both
+    """
+    def is_special_multiple(num):
+        """Check if a number is a multiple of 3 or 5, but not both."""
+        is_multiple_of_3 = num % 3 == 0
+        is_multiple_of_5 = num % 5 == 0
+        return (is_multiple_of_3 or is_multiple_of_5) and not (is_multiple_of_3 and is_multiple_of_5)
+    
+    return sorted(list(filter(is_special_multiple, numbers)))

--- a/tests/test_filter_multiples.py
+++ b/tests/test_filter_multiples.py
@@ -1,0 +1,29 @@
+import pytest
+from src.filter_multiples import filter_special_multiples
+
+def test_filter_special_multiples_basic():
+    """Test basic functionality of filtering multiples."""
+    input_list = [1, 2, 3, 4, 5, 6, 9, 10, 12, 15, 18, 20]
+    expected = [3, 5, 6, 9, 10, 12, 18, 20]
+    assert filter_special_multiples(input_list) == expected
+
+def test_filter_special_multiples_empty_list():
+    """Test with an empty list."""
+    assert filter_special_multiples([]) == []
+
+def test_filter_special_multiples_no_matches():
+    """Test when no numbers match the criteria."""
+    input_list = [1, 2, 4, 7, 11, 13]
+    assert filter_special_multiples(input_list) == []
+
+def test_filter_special_multiples_all_matches():
+    """Test when all numbers match the criteria."""
+    input_list = [3, 5, 6, 9, 10, 12, 15, 18, 20]
+    expected = [3, 5, 6, 9, 10, 12, 18, 20]
+    assert filter_special_multiples(input_list) == expected
+
+def test_filter_special_multiples_negative_numbers():
+    """Test with negative numbers."""
+    input_list = [-3, -5, -6, -9, -10, -15, 3, 5, 6, 9, 10, 15]
+    expected = [-9, -6, -5, -3, 3, 5, 6, 9, 10]
+    assert filter_special_multiples(input_list) == expected


### PR DESCRIPTION
# Implement Selective Multiple Filtering Function

## Task
Create a function that takes a list of integers and returns a new list containing integers that are multiples of either 3 or 5, but not both. The output list must be sorted in ascending order.

## Acceptance Criteria
All tests must pass. The function must filter numbers that are multiples of 3 or 5, but exclude numbers that are multiples of both. The returned list must be sorted in ascending order. The function must work for any input list of integers.

## Summary of Changes
Added a new function to filter integers that are multiples of 3 or 5, excluding numbers divisible by both 3 and 5. The function returns a sorted list of these selective multiples.

## Test Cases
 - Verify the function returns an empty list when no numbers meet the criteria
 - Check that numbers divisible by both 3 and 5 are excluded
 - Ensure the returned list is sorted in ascending order
 - Test the function with a list containing positive and negative integers
 - Validate the function works with an empty input list
 - Confirm the function correctly identifies and filters multiples of 3 and 5