### PR TITLE
Implement String to Alternating Pascal Case Conversion Function

### DIFF
--- a/src/alternating_pascal_case.py
+++ b/src/alternating_pascal_case.py
@@ -1,0 +1,33 @@
+def convert_to_alternating_pascal_case(input_string):
+    """
+    Convert a string to alternating Pascal case.
+    
+    Args:
+        input_string (str): The input string to convert.
+    
+    Returns:
+        str: The string converted to alternating Pascal case.
+    
+    Raises:
+        TypeError: If input is not a string.
+    """
+    if not isinstance(input_string, str):
+        raise TypeError("Input must be a string")
+    
+    # Remove non-alphanumeric characters and split into words
+    words = ''.join(char if char.isalnum() else ' ' for char in input_string).split()
+    
+    if not words:
+        return ''
+    
+    # Convert words to alternating case
+    result_words = []
+    for i, word in enumerate(words):
+        if i % 2 == 0:
+            # Even index words (0, 2, 4...) in upper camel (Pascal) case
+            result_words.append(word.capitalize())
+        else:
+            # Odd index words in lower case
+            result_words.append(word.lower())
+    
+    return ''.join(result_words)

--- a/tests/test_alternating_pascal_case.py
+++ b/tests/test_alternating_pascal_case.py
@@ -1,0 +1,28 @@
+import pytest
+from src.alternating_pascal_case import convert_to_alternating_pascal_case
+
+def test_convert_to_alternating_pascal_case():
+    # Test various input scenarios
+    assert convert_to_alternating_pascal_case("hello world") == "HelloWorld"
+    assert convert_to_alternating_pascal_case("python is awesome") == "PythonIsAwesome"
+    assert convert_to_alternating_pascal_case("a b c d") == "ABCd"
+    
+    # Test with special characters
+    assert convert_to_alternating_pascal_case("hello, world!") == "HelloWorld"
+    assert convert_to_alternating_pascal_case("python 2.0 rocks") == "Python2Rocks"
+    
+    # Test edge cases
+    assert convert_to_alternating_pascal_case("") == ""
+    assert convert_to_alternating_pascal_case("single") == "Single"
+    
+    # Test error handling
+    with pytest.raises(TypeError):
+        convert_to_alternating_pascal_case(None)
+    
+    with pytest.raises(TypeError):
+        convert_to_alternating_pascal_case(123)
+
+def test_alternating_case_pattern():
+    # Additional tests to verify alternating case pattern
+    assert convert_to_alternating_pascal_case("one two three four") == "OneTwoThreeFour"
+    assert convert_to_alternating_pascal_case("red green blue yellow") == "RedGreenBlueYellow"


### PR DESCRIPTION
# Implement String to Alternating Pascal Case Conversion Function

## Task
Write a function to convert a string to alternating Pascal case

## Acceptance Criteria
All tests must pass

## Summary of Changes
Added a new utility function that converts a given string to alternating Pascal case, where every other word is capitalized in a unique pattern

## Test Cases
 - Verify the function correctly converts a simple string to alternating Pascal case
 - Check handling of strings with multiple words
 - Test conversion of strings with special characters or mixed case
 - Ensure function works with empty and single-word strings
 - Validate the function handles strings with numbers and punctuation