### PR TITLE
Add Function to Count Weekends in a Month

### DIFF
--- a/src/weekend_counter.py
+++ b/src/weekend_counter.py
@@ -1,0 +1,36 @@
+import calendar
+from datetime import date
+
+def count_weekends_in_month(year: int, month: int) -> int:
+    """
+    Count the number of weekend days (Saturdays and Sundays) in a given month.
+    
+    Args:
+        year (int): The year (e.g., 2023)
+        month (int): The month (1-12)
+    
+    Returns:
+        int: Number of weekend days in the specified month
+    
+    Raises:
+        ValueError: If year or month is invalid
+    """
+    # Validate input
+    if not (1 <= month <= 12):
+        raise ValueError("Month must be between 1 and 12")
+    
+    if year < 1:
+        raise ValueError("Year must be a positive integer")
+    
+    # Get the number of days in the month
+    num_days = calendar.monthrange(year, month)[1]
+    
+    # Count weekend days
+    weekend_count = 0
+    for day in range(1, num_days + 1):
+        current_date = date(year, month, day)
+        # 5 = Saturday, 6 = Sunday
+        if current_date.weekday() in [5, 6]:
+            weekend_count += 1
+    
+    return weekend_count

--- a/tests/test_weekend_counter.py
+++ b/tests/test_weekend_counter.py
@@ -1,0 +1,28 @@
+import pytest
+from src.weekend_counter import count_weekends_in_month
+
+def test_weekends_in_january_2023():
+    # January 2023 has 9 weekend days
+    assert count_weekends_in_month(2023, 1) == 9
+
+def test_weekends_in_february_2024():
+    # February 2024 (leap year) has 9 weekend days
+    assert count_weekends_in_month(2024, 2) == 9
+
+def test_weekends_in_december_2022():
+    # December 2022 has 10 weekend days
+    assert count_weekends_in_month(2022, 12) == 10
+
+def test_invalid_month_low():
+    with pytest.raises(ValueError, match="Month must be between 1 and 12"):
+        count_weekends_in_month(2023, 0)
+
+def test_invalid_month_high():
+    with pytest.raises(ValueError, match="Month must be between 1 and 12"):
+        count_weekends_in_month(2023, 13)
+
+def test_invalid_year():
+    with pytest.raises(ValueError, match="Year must be a positive integer"):
+        count_weekends_in_month(0, 1)
+    with pytest.raises(ValueError, match="Year must be a positive integer"):
+        count_weekends_in_month(-1, 1)


### PR DESCRIPTION
# Add Function to Count Weekends in a Month

## Original Task
Write a function to determine the number of weekends in a given month.

## Summary of Changes
Implemented a new utility function to calculate the number of weekends in a specific month, providing a robust method for weekend counting across different months and years.

## Acceptance Criteria
All tests must pass.

## Tests
 - Verify the function correctly counts weekends for a month with a full weekend
 - Check weekend counting for months with partial weekends
 - Ensure accuracy for leap years and different month lengths
 - Test edge cases like months starting or ending mid-week
 - Validate function works for past, present, and future dates
