### PR TITLE
Add Fahrenheit to Celsius Temperature Conversion Function

### DIFF
--- a/src/temperature_converter.py
+++ b/src/temperature_converter.py
@@ -1,0 +1,18 @@
+def fahrenheit_to_celsius(fahrenheit):
+    """
+    Convert temperature from Fahrenheit to Celsius.
+    
+    Args:
+        fahrenheit (float): Temperature in Fahrenheit
+    
+    Returns:
+        float: Temperature in Celsius
+    
+    Raises:
+        TypeError: If input is not a number
+    """
+    if not isinstance(fahrenheit, (int, float)):
+        raise TypeError("Input must be a number")
+    
+    celsius = (fahrenheit - 32) * 5/9
+    return round(celsius, 2)

--- a/tests/test_temperature_converter.py
+++ b/tests/test_temperature_converter.py
@@ -1,0 +1,27 @@
+import pytest
+from src.temperature_converter import fahrenheit_to_celsius
+
+def test_freezing_point():
+    """Test conversion of freezing point (32°F = 0°C)"""
+    assert fahrenheit_to_celsius(32) == 0
+
+def test_boiling_point():
+    """Test conversion of boiling point (212°F = 100°C)"""
+    assert fahrenheit_to_celsius(212) == 100
+
+def test_negative_temperature():
+    """Test conversion of a negative temperature"""
+    assert fahrenheit_to_celsius(-40) == -40
+
+def test_decimal_temperature():
+    """Test conversion of a decimal temperature"""
+    assert fahrenheit_to_celsius(98.6) == 37
+
+def test_invalid_input_type():
+    """Test that TypeError is raised for non-numeric input"""
+    with pytest.raises(TypeError, match="Input must be a number"):
+        fahrenheit_to_celsius("not a number")
+        
+def test_large_number():
+    """Test conversion of a large temperature"""
+    assert fahrenheit_to_celsius(1000) == 537.78


### PR DESCRIPTION
# Add Fahrenheit to Celsius Temperature Conversion Function

## Original Task
Write a function to convert Fahrenheit to Celsius.

## Summary of Changes
Implemented a new utility function to convert temperatures from Fahrenheit to Celsius. The function takes a Fahrenheit temperature as input and returns the equivalent Celsius temperature using the standard conversion formula: (F - 32) * 5/9.

## Acceptance Criteria
All tests must pass.

## Tests
 - Verifies that the conversion function correctly transforms freezing point (32°F) to 0°C
 - Checks conversion of boiling point (212°F) to 100°C
 - Ensures negative temperature conversion works correctly
 - Tests conversion of decimal temperature values
 - Validates input handling for edge cases and extreme temperatures
