### PR TITLE
Implement Rightmost Set Bit Position Finder

### DIFF
--- a/src/rightmost_set_bit.py
+++ b/src/rightmost_set_bit.py
@@ -1,0 +1,34 @@
+def find_rightmost_set_bit(number):
+    """
+    Determine the position of the rightmost set bit in a number.
+    
+    Args:
+        number (int): The input number to find the rightmost set bit.
+    
+    Returns:
+        int: The position of the rightmost set bit (1-indexed), or 0 if no set bit exists.
+    
+    Raises:
+        TypeError: If the input is not an integer.
+        ValueError: If the input is a negative number.
+    """
+    # Input validation
+    if not isinstance(number, int):
+        raise TypeError("Input must be an integer")
+    
+    if number < 0:
+        raise ValueError("Input must be a non-negative integer")
+    
+    # Special case for 0
+    if number == 0:
+        return 0
+    
+    # Use bitwise operations to find the rightmost set bit
+    position = 1
+    while number > 0:
+        if number & 1:
+            return position
+        number >>= 1
+        position += 1
+    
+    return 0

--- a/tests/test_rightmost_set_bit.py
+++ b/tests/test_rightmost_set_bit.py
@@ -1,0 +1,26 @@
+import pytest
+from src.rightmost_set_bit import find_rightmost_set_bit
+
+def test_find_rightmost_set_bit():
+    # Test basic cases
+    assert find_rightmost_set_bit(0) == 0      # No set bits
+    assert find_rightmost_set_bit(1) == 1      # First bit set
+    assert find_rightmost_set_bit(8) == 4      # Fourth bit set
+    assert find_rightmost_set_bit(16) == 5     # Fifth bit set
+    
+    # Test multiple set bits
+    assert find_rightmost_set_bit(10) == 2     # Binary 1010 - rightmost set bit at 2nd position
+    assert find_rightmost_set_bit(7) == 1      # Binary 111 - rightmost at 1st position
+    
+    # Large number test
+    assert find_rightmost_set_bit(1024) == 11  # 2^10, 11th bit set
+    
+    # Error handling
+    with pytest.raises(TypeError):
+        find_rightmost_set_bit("not a number")
+    
+    with pytest.raises(TypeError):
+        find_rightmost_set_bit(3.14)
+    
+    with pytest.raises(ValueError):
+        find_rightmost_set_bit(-5)


### PR DESCRIPTION
# Implement Rightmost Set Bit Position Finder

## Original Task
Write a function to determine the position of the rightmost set bit in a number.

## Summary of Changes
Added a new utility function to efficiently find the position of the rightmost set bit in a given number. The implementation uses bitwise operations to determine the position with minimal computational complexity.

## Acceptance Criteria
All tests must pass.

## Tests
 - Verifies the function returns 0 for a number with only the least significant bit set
 - Checks the function works correctly for numbers with set bits in different positions
 - Ensures the function handles zero input correctly
 - Tests the function with large numbers and various bit patterns
