### PR TITLE
Implement find_pair_with_target Function

### DIFF
--- a/src/find_pair_with_target.py
+++ b/src/find_pair_with_target.py
@@ -1,0 +1,31 @@
+def find_pair_with_target(nums, target):
+    """
+    Find index pairs of unique integers that sum up to the target.
+    
+    Args:
+        nums (list): A list of unique integers
+        target (int): The target sum to find
+    
+    Returns:
+        list: A list of index pairs where nums[i] + nums[j] == target
+    """
+    # Create a dictionary to store complement values and their indices
+    complement_dict = {}
+    
+    # List to store the result index pairs
+    result = []
+    
+    # Iterate through the list with index
+    for i, num in enumerate(nums):
+        # Calculate the complement needed to reach the target
+        complement = target - num
+        
+        # Check if the complement exists in the dictionary
+        if complement in complement_dict:
+            # Add the index pair to the result
+            result.append([complement_dict[complement], i])
+        
+        # Store the current number's index 
+        complement_dict[num] = i
+    
+    return result

--- a/tests/test_find_pair_with_target.py
+++ b/tests/test_find_pair_with_target.py
@@ -1,0 +1,28 @@
+import pytest
+from src.find_pair_with_target import find_pair_with_target
+
+def test_find_pair_with_target_basic():
+    nums = [2, 7, 11, 15]
+    target = 9
+    assert sorted(find_pair_with_target(nums, target)) == [[0, 1]]
+
+def test_find_pair_with_target_multiple_pairs():
+    nums = [3, 2, 4, 1, 5]
+    target = 6
+    result = sorted(find_pair_with_target(nums, target))
+    assert result == [[1, 2], [2, 4]]
+
+def test_find_pair_with_target_no_pairs():
+    nums = [1, 2, 3, 4, 5]
+    target = 10
+    assert find_pair_with_target(nums, target) == []
+
+def test_find_pair_with_target_empty_list():
+    nums = []
+    target = 5
+    assert find_pair_with_target(nums, target) == []
+
+def test_find_pair_with_target_large_list():
+    nums = list(range(1000))
+    target = 1999
+    assert sorted(find_pair_with_target(nums, target)) == [[999, 1000]]


### PR DESCRIPTION
# Implement find_pair_with_target Function

## Original Task
Write a function called find_pair_with_target that takes a list of unique integers nums and a target sum target as parameters. The function should return a list of index pairs where the numbers at those indices add up to the target.

## Summary of Changes
Added a new function find_pair_with_target that efficiently finds index pairs in a list of unique integers that sum up to a given target. Implemented with a hash-based approach for O(n) time complexity and O(n) space complexity.

## Acceptance Criteria
All tests must pass. The function must return a list of index pairs in the format [(index1, index2), ...]. If no pairs exist that sum to the target, return an empty list. Each pair must represent unique indices where the corresponding numbers add up to the target. Assume no more than one pair exists with the same elements.

## Tests
 - Verify the function returns correct index pairs for a list with multiple valid pairs
 - Check that the function returns an empty list when no pairs sum to the target
 - Ensure the function handles lists with various sizes and integer values
 - Confirm that only unique index pairs are returned
 - Test with edge cases like a list with minimum length or maximum possible integer values
