### PR TITLE
Implement Fahrenheit to Celsius Temperature Conversion

### DIFF
--- a/src/temperature_converter.py
+++ b/src/temperature_converter.py
@@ -1,0 +1,18 @@
+def fahrenheit_to_celsius(fahrenheit):
+    """
+    Convert temperature from Fahrenheit to Celsius.
+    
+    Args:
+        fahrenheit (float): Temperature in Fahrenheit
+    
+    Returns:
+        float: Temperature in Celsius
+    
+    Raises:
+        TypeError: If input is not a number
+    """
+    if not isinstance(fahrenheit, (int, float)):
+        raise TypeError("Input must be a number")
+    
+    celsius = (fahrenheit - 32) * 5/9
+    return round(celsius, 2)

--- a/tests/test_temperature_converter.py
+++ b/tests/test_temperature_converter.py
@@ -1,0 +1,27 @@
+import pytest
+from src.temperature_converter import fahrenheit_to_celsius
+
+def test_freezing_point():
+    """Test conversion of 32Â°F to 0Â°C"""
+    assert fahrenheit_to_celsius(32) == 0
+
+def test_boiling_point():
+    """Test conversion of 212Â°F to 100Â°C"""
+    assert fahrenheit_to_celsius(212) == 100
+
+def test_negative_temperature():
+    """Test conversion of a negative temperature"""
+    assert fahrenheit_to_celsius(-40) == -40
+
+def test_decimal_temperature():
+    """Test conversion of a decimal temperature"""
+    assert fahrenheit_to_celsius(98.6) == 37
+
+def test_type_error():
+    """Test that TypeError is raised for non-numeric input"""
+    with pytest.raises(TypeError):
+        fahrenheit_to_celsius("not a number")
+
+def test_large_number():
+    """Test conversion of a large temperature number"""
+    assert fahrenheit_to_celsius(1000) == 537.78


### PR DESCRIPTION
# Implement Fahrenheit to Celsius Temperature Conversion

## Task
Write a function to convert Fahrenheit to Celsius.

## Acceptance Criteria
All tests must pass.

## Summary of Changes
Added a new utility function to convert temperatures from Fahrenheit to Celsius. The function takes a Fahrenheit temperature as input and returns the equivalent Celsius temperature using the standard conversion formula: (F - 32) * 5/9.

## Test Cases
 - Verify the conversion of 32°F to 0°C
 - Verify the conversion of 212°F to 100°C
 - Verify the conversion of negative temperatures
 - Ensure the function handles decimal input correctly
 - Check that the conversion returns the correct floating-point precision