### PR TITLE
Implement Permission-Based Console Message Logging

### DIFF
--- a/src/console_logger.py
+++ b/src/console_logger.py
@@ -1,0 +1,59 @@
+from enum import Enum
+from typing import Optional, Union
+
+class UserPermissionLevel(Enum):
+    """Enumeration of user permission levels."""
+    GUEST = 0
+    USER = 1
+    ADMIN = 2
+
+class ConsoleLogger:
+    """
+    A logger that controls message logging based on user permission levels.
+    
+    This class provides a method to log messages with different verbosity levels
+    depending on the user's permission level.
+    """
+    
+    @staticmethod
+    def log_message(
+        message: str, 
+        user_permission: UserPermissionLevel, 
+        min_permission_level: UserPermissionLevel = UserPermissionLevel.USER
+    ) -> Optional[str]:
+        """
+        Log a message based on user permissions.
+        
+        Args:
+            message (str): The message to be logged
+            user_permission (UserPermissionLevel): Current user's permission level
+            min_permission_level (UserPermissionLevel, optional): 
+                Minimum permission level required to log the message. 
+                Defaults to UserPermissionLevel.USER.
+        
+        Returns:
+            Optional[str]: The logged message if permission is sufficient, 
+                           None otherwise
+        
+        Raises:
+            ValueError: If message is empty or None
+            TypeError: If incorrect types are provided
+        """
+        # Validate inputs
+        if message is None or message.strip() == "":
+            raise ValueError("Message cannot be empty or None")
+        
+        if not isinstance(user_permission, UserPermissionLevel):
+            raise TypeError("user_permission must be a UserPermissionLevel")
+        
+        if not isinstance(min_permission_level, UserPermissionLevel):
+            raise TypeError("min_permission_level must be a UserPermissionLevel")
+        
+        # Check if user has sufficient permissions to log the message
+        if user_permission.value >= min_permission_level.value:
+            # In a real-world scenario, this might use a proper logging framework
+            print(f"[{user_permission.name}] {message}")
+            return message
+        
+        # If insufficient permissions, return None
+        return None

--- a/tests/test_console_logger.py
+++ b/tests/test_console_logger.py
@@ -1,0 +1,76 @@
+import pytest
+from src.console_logger import ConsoleLogger, UserPermissionLevel
+
+class TestConsoleLogger:
+    def test_log_message_admin_full_access(self, capsys):
+        """Test that admin can log messages at all levels"""
+        message = "Admin message"
+        result = ConsoleLogger.log_message(
+            message, 
+            user_permission=UserPermissionLevel.ADMIN
+        )
+        captured = capsys.readouterr()
+        assert result == message
+        assert "[ADMIN]" in captured.out
+        assert message in captured.out
+
+    def test_log_message_user_default_level(self, capsys):
+        """Test that a regular user can log messages at default level"""
+        message = "User message"
+        result = ConsoleLogger.log_message(
+            message, 
+            user_permission=UserPermissionLevel.USER
+        )
+        captured = capsys.readouterr()
+        assert result == message
+        assert "[USER]" in captured.out
+        assert message in captured.out
+
+    def test_log_message_guest_insufficient_permission(self, capsys):
+        """Test that a guest cannot log messages above their permission level"""
+        message = "Guest message"
+        result = ConsoleLogger.log_message(
+            message, 
+            user_permission=UserPermissionLevel.GUEST,
+            min_permission_level=UserPermissionLevel.USER
+        )
+        captured = capsys.readouterr()
+        assert result is None
+        assert captured.out == ""
+
+    def test_log_message_empty_message_raises_error(self):
+        """Test that empty messages raise a ValueError"""
+        with pytest.raises(ValueError, match="Message cannot be empty or None"):
+            ConsoleLogger.log_message(
+                "", 
+                user_permission=UserPermissionLevel.USER
+            )
+
+    def test_log_message_none_message_raises_error(self):
+        """Test that None messages raise a ValueError"""
+        with pytest.raises(ValueError, match="Message cannot be empty or None"):
+            ConsoleLogger.log_message(
+                None, 
+                user_permission=UserPermissionLevel.USER
+            )
+
+    def test_log_message_invalid_permission_type(self):
+        """Test that invalid permission types raise a TypeError"""
+        with pytest.raises(TypeError, match="user_permission must be a UserPermissionLevel"):
+            ConsoleLogger.log_message(
+                "Test message", 
+                user_permission="not a permission"
+            )
+
+    def test_log_message_custom_min_permission(self, capsys):
+        """Test logging with a custom minimum permission level"""
+        message = "Admin-only message"
+        result = ConsoleLogger.log_message(
+            message, 
+            user_permission=UserPermissionLevel.ADMIN,
+            min_permission_level=UserPermissionLevel.ADMIN
+        )
+        captured = capsys.readouterr()
+        assert result == message
+        assert "[ADMIN]" in captured.out
+        assert message in captured.out


### PR DESCRIPTION
# Implement Permission-Based Console Message Logging

## Original Task
Write a function to log console messages based on user permissions

## Summary of Changes
Added a new function to log console messages with permission-based access control

## Acceptance Criteria
All tests must pass

## Tests
 - Verify logging function respects user permission levels
 - Check that unauthorized users cannot log messages
 - Ensure different permission levels have appropriate logging capabilities
