### PR TITLE
Implement Exclusive Multiples of 3 or 5 Filter Function

### DIFF
--- a/src/filter_multiples.py
+++ b/src/filter_multiples.py
@@ -1,0 +1,28 @@
+def filter_exclusive_multiples(numbers):
+    """
+    Filter a list of integers to include only numbers that are multiples 
+    of either 3 or 5, but not both.
+
+    Args:
+        numbers (list): A list of integers to filter.
+
+    Returns:
+        list: A sorted list of integers that are multiples of 3 or 5, 
+              but not both.
+
+    Examples:
+        >>> filter_exclusive_multiples([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        [5, 6, 7, 9, 10]
+    """
+    # Validate input is a list
+    if not isinstance(numbers, list):
+        raise TypeError("Input must be a list of integers")
+    
+    # Filter numbers that are multiples of 3 XOR 5 (exclusive or)
+    exclusive_multiples = [
+        num for num in numbers 
+        if (num % 3 == 0) != (num % 5 == 0)
+    ]
+    
+    # Return sorted list
+    return sorted(exclusive_multiples)

--- a/src/filter_multiples.py
+++ b/src/filter_multiples.py
@@ -18,10 +18,10 @@ def filter_exclusive_multiples(numbers):
     if not isinstance(numbers, list):
         raise TypeError("Input must be a list of integers")
     
-    # Filter numbers that are multiples of 3 XOR 5 (exclusive or)
+    # Filter numbers that are either multiple of 3 or 5, but not both
     exclusive_multiples = [
         num for num in numbers 
-        if (num % 3 == 0) != (num % 5 == 0)
+        if (num % 3 == 0) ^ (num % 5 == 0)
     ]
     
     # Return sorted list

--- a/tests/test_filter_multiples.py
+++ b/tests/test_filter_multiples.py
@@ -1,0 +1,36 @@
+import pytest
+from src.filter_multiples import filter_exclusive_multiples
+
+def test_basic_filtering():
+    """Test basic filtering of exclusive multiples."""
+    input_list = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    expected = [5, 6, 7, 9, 10]
+    assert filter_exclusive_multiples(input_list) == expected
+
+def test_empty_list():
+    """Test filtering an empty list."""
+    assert filter_exclusive_multiples([]) == []
+
+def test_no_exclusive_multiples():
+    """Test a list with no exclusive multiples."""
+    input_list = [1, 2, 4, 8]
+    assert filter_exclusive_multiples(input_list) == []
+
+def test_all_exclusive_multiples():
+    """Test a list with only exclusive multiples."""
+    input_list = [3, 5, 6, 9, 10]
+    expected = [3, 5, 6, 9, 10]
+    assert filter_exclusive_multiples(input_list) == expected
+
+def test_sorting():
+    """Test that the output is sorted."""
+    input_list = [10, 3, 15, 6, 5]
+    expected = [3, 5, 6, 10]
+    assert filter_exclusive_multiples(input_list) == expected
+
+def test_invalid_input_type():
+    """Test that a TypeError is raised for non-list inputs."""
+    with pytest.raises(TypeError, match="Input must be a list of integers"):
+        filter_exclusive_multiples("not a list")
+        filter_exclusive_multiples(123)
+        filter_exclusive_multiples(None)

--- a/tests/test_filter_multiples.py
+++ b/tests/test_filter_multiples.py
@@ -4,7 +4,7 @@ from src.filter_multiples import filter_exclusive_multiples
 def test_basic_filtering():
     """Test basic filtering of exclusive multiples."""
     input_list = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    expected = [5, 6, 7, 9, 10]
+    expected = [3, 5, 6, 9, 10]
     assert filter_exclusive_multiples(input_list) == expected
 
 def test_empty_list():


### PR DESCRIPTION
# Implement Exclusive Multiples of 3 or 5 Filter Function

## Original Task
Create a function that takes a list of integers and returns a new list containing integers that are multiples of either 3 or 5, but not both. The output list must be sorted in ascending order.

## Summary of Changes
Added a new function to filter integers that are multiples of 3 or 5, excluding numbers that are multiples of both

## Acceptance Criteria
- Function must filter numbers that are multiples of 3 or 5
- Exclude numbers that are multiples of both 3 and 5
- Returned list must be sorted in ascending order
- Function must work for any input list of integers

## Tests
 - Verify function returns correct filtered list
 - Check sorting of output list
 - Test with list containing multiples of 3 and 5
 - Test with empty list
 - Test with list containing no qualifying numbers
