### PR TITLE
Implement validate_phone_number Function with Precise Format Validation

### DIFF
--- a/src/phone_validator.py
+++ b/src/phone_validator.py
@@ -12,7 +12,14 @@ def validate_phone_number(phone_number: str) -> bool:
 
     Returns:
         bool: True if the phone number matches one of the valid formats, False otherwise
+    
+    Raises:
+        TypeError: If input is not a string
     """
+    # Check if input is None or not a string
+    if phone_number is None or not isinstance(phone_number, str):
+        raise TypeError("Input must be a string")
+    
     # Regular expression patterns for the three specified formats
     patterns = [
         r'^\(\d{3}\)\s\d{3}-\d{4}$',   # (123) 456-7890

--- a/src/phone_validator.py
+++ b/src/phone_validator.py
@@ -1,0 +1,27 @@
+import re
+
+def validate_phone_number(phone_number: str) -> bool:
+    """
+    Validate a phone number against three specific formats:
+    1. (123) 456-7890
+    2. 123-456-7890
+    3. 123 456 7890
+
+    Args:
+        phone_number (str): The phone number to validate
+
+    Returns:
+        bool: True if the phone number matches one of the valid formats, False otherwise
+    """
+    # Regular expression patterns for the three specified formats
+    patterns = [
+        r'^\(\d{3}\)\s\d{3}-\d{4}$',   # (123) 456-7890
+        r'^\d{3}-\d{3}-\d{4}$',        # 123-456-7890
+        r'^\d{3}\s\d{3}\s\d{4}$'       # 123 456 7890
+    ]
+    
+    # Remove any whitespace from the input
+    phone_number = phone_number.strip()
+    
+    # Check if the phone number matches any of the patterns
+    return any(re.match(pattern, phone_number) for pattern in patterns)

--- a/tests/test_phone_validator.py
+++ b/tests/test_phone_validator.py
@@ -1,0 +1,39 @@
+import pytest
+from src.phone_validator import validate_phone_number
+
+def test_valid_phone_number_formats():
+    """Test valid phone number formats"""
+    # Test format 1: (123) 456-7890
+    assert validate_phone_number('(123) 456-7890') == True
+    
+    # Test format 2: 123-456-7890
+    assert validate_phone_number('123-456-7890') == True
+    
+    # Test format 3: 123 456 7890
+    assert validate_phone_number('123 456 7890') == True
+
+def test_invalid_phone_number_formats():
+    """Test invalid phone number formats"""
+    # Test invalid formats
+    assert validate_phone_number('123.456.7890') == False  # Dot separator
+    assert validate_phone_number('1234567890') == False  # No separators
+    assert validate_phone_number('(123)456-7890') == False  # Missing space after parenthesis
+    assert validate_phone_number('(123) 456 7890') == False  # Mixed separators
+    assert validate_phone_number('(123) 45-67890') == False  # Incorrect grouping
+    
+def test_edge_cases():
+    """Test edge cases"""
+    # Test whitespace handling
+    assert validate_phone_number(' (123) 456-7890 ') == True
+    
+    # Test empty string
+    assert validate_phone_number('') == False
+    
+    # Test None input
+    with pytest.raises(TypeError):
+        validate_phone_number(None)
+    
+def test_non_numeric_characters():
+    """Test phone numbers with non-numeric characters"""
+    assert validate_phone_number('(abc) def-ghij') == False
+    assert validate_phone_number('123-abc-defg') == False


### PR DESCRIPTION
# Implement validate_phone_number Function with Precise Format Validation

## Original Task
Write a function called validate_phone_number that takes a string input and returns true if the phone number is valid in one of three specific formats: (123) 456-7890, 123-456-7890, or 123 456 7890.

## Summary of Changes
Added a robust phone number validation function that checks for three specific US phone number formats

## Acceptance Criteria
1. Function must validate phone numbers in exactly three formats
2. Input string must have length of 12
3. Must contain exactly three hyphens or spaces
4. Must have the correct number of digits in each section
5. First and second sections must be between 1-9 digits
6. Third section must be between 1-9 digits
7. Must return false for invalid phone number formats

## Tests
 - Test function with valid formats (123) 456-7890, 123-456-7890, and 123 456 7890
 - Test function with invalid formats
 - Verify correct digit validation for each section
 - Check handling of edge cases like incorrect spacing or separator characters
