### PR TITLE
Implement validate_phone_number Function with Specific Format Validation

### DIFF
--- a/src/phone_number_validator.py
+++ b/src/phone_number_validator.py
@@ -1,0 +1,27 @@
+import re
+
+def validate_phone_number(phone_number: str) -> bool:
+    """
+    Validate a phone number against three specific formats:
+    1. (123) 456-7890
+    2. 123-456-7890
+    3. 123 456 7890
+
+    Args:
+        phone_number (str): The phone number to validate
+
+    Returns:
+        bool: True if the phone number matches one of the valid formats, False otherwise
+    """
+    # Regex patterns for the three valid phone number formats
+    patterns = [
+        r'^\(\d{3}\)\s\d{3}-\d{4}$',     # (123) 456-7890
+        r'^\d{3}-\d{3}-\d{4}$',          # 123-456-7890
+        r'^\d{3}\s\d{3}\s\d{4}$'         # 123 456 7890
+    ]
+    
+    # Remove any leading/trailing whitespace
+    phone_number = phone_number.strip()
+    
+    # Check if the phone number matches any of the valid patterns
+    return any(re.match(pattern, phone_number) for pattern in patterns)

--- a/src/phone_number_validator.py
+++ b/src/phone_number_validator.py
@@ -13,6 +13,10 @@ def validate_phone_number(phone_number: str) -> bool:
     Returns:
         bool: True if the phone number matches one of the valid formats, False otherwise
     """
+    # Handle None or non-string input
+    if phone_number is None or not isinstance(phone_number, str):
+        return False
+    
     # Regex patterns for the three valid phone number formats
     patterns = [
         r'^\(\d{3}\)\s\d{3}-\d{4}$',     # (123) 456-7890

--- a/tests/test_phone_number_validator.py
+++ b/tests/test_phone_number_validator.py
@@ -1,0 +1,29 @@
+import pytest
+from src.phone_number_validator import validate_phone_number
+
+def test_valid_phone_number_formats():
+    """Test all three valid phone number formats"""
+    assert validate_phone_number('(123) 456-7890') == True
+    assert validate_phone_number('123-456-7890') == True
+    assert validate_phone_number('123 456 7890') == True
+
+def test_invalid_phone_number_formats():
+    """Test various invalid phone number formats"""
+    assert validate_phone_number('1234567890') == False  # No separators
+    assert validate_phone_number('(123)456-7890') == False  # Missing space
+    assert validate_phone_number('(123) 456 7890') == False  # Mixed separators
+    assert validate_phone_number('(123) 45-67890') == False  # Incorrect digit grouping
+    assert validate_phone_number('(123) 456-789') == False  # Too few digits
+    assert validate_phone_number('(123) 456-78901') == False  # Too many digits
+
+def test_edge_cases():
+    """Test edge cases and boundary conditions"""
+    assert validate_phone_number('') == False  # Empty string
+    assert validate_phone_number('   ') == False  # Whitespace
+    assert validate_phone_number(None) == False  # None input (will raise TypeError)
+    
+def test_whitespace_handling():
+    """Test whitespace handling at start and end"""
+    assert validate_phone_number('  (123) 456-7890  ') == True
+    assert validate_phone_number('  123-456-7890  ') == True
+    assert validate_phone_number('  123 456 7890  ') == True


### PR DESCRIPTION
# Implement validate_phone_number Function with Specific Format Validation

## Original Task
Write a function called validate_phone_number that takes a string input and returns true if the phone number is valid in one of three specific formats: (123) 456-7890, 123-456-7890, or 123 456 7890.

## Summary of Changes
Added a new function to validate phone numbers in three specific formats: (123) 456-7890, 123-456-7890, and 123 456 7890.

## Acceptance Criteria
- Function must validate phone numbers in exactly three formats
- Input string must have length of 12
- Must contain exactly three hyphens or spaces
- Must have the correct number of digits in each section
- First and second sections must be between 1-9 digits
- Third section must be between 1-9 digits
- Must return false for invalid phone number formats

## Tests
 - Validate phone number in (123) 456-7890 format
 - Validate phone number in 123-456-7890 format
 - Validate phone number in 123 456 7890 format
 - Reject phone numbers with incorrect formatting
 - Check digit count in each section
 - Ensure return type is boolean
