### PR TITLE
Implement Floyd-Warshall Algorithm for Shortest Paths

### DIFF
--- a/src/floyd_warshall.py
+++ b/src/floyd_warshall.py
@@ -1,0 +1,44 @@
+from typing import List, Union, Optional
+
+def floyd_warshall(graph: List[List[Union[int, float]]]) -> Optional[List[List[Union[int, float]]]]:
+    """
+    Implement the Floyd-Warshall algorithm to find shortest paths between all pairs of vertices.
+    
+    Args:
+        graph (List[List[Union[int, float]]]): Adjacency matrix representing the graph.
+                                               Use float('inf') for no direct connection.
+    
+    Returns:
+        Optional[List[List[Union[int, float]]]]: Distance matrix with shortest paths between all vertices,
+                                                 or None if negative cycle is detected.
+    
+    Raises:
+        ValueError: If input graph is not a valid square matrix.
+    """
+    # Validate input graph
+    if not graph or len(graph) == 0:
+        raise ValueError("Graph cannot be empty")
+    
+    # Check if graph is a square matrix
+    n = len(graph)
+    if any(len(row) != n for row in graph):
+        raise ValueError("Graph must be a square matrix")
+    
+    # Create a copy of the input graph to avoid modifying the original
+    dist = [row.copy() for row in graph]
+    
+    # Floyd-Warshall algorithm core
+    for k in range(n):
+        for i in range(n):
+            for j in range(n):
+                # Check for potential overflow and update shortest path
+                if (dist[i][k] != float('inf') and 
+                    dist[k][j] != float('inf') and 
+                    dist[i][k] + dist[k][j] < dist[i][j]):
+                    dist[i][j] = dist[i][k] + dist[k][j]
+        
+        # Detect negative cycle
+        if dist[k][k] < 0:
+            return None
+    
+    return dist

--- a/tests/test_floyd_warshall.py
+++ b/tests/test_floyd_warshall.py
@@ -1,0 +1,79 @@
+import pytest
+import math
+from src.floyd_warshall import floyd_warshall
+
+def test_floyd_warshall_basic_graph():
+    """Test Floyd-Warshall on a basic connected graph."""
+    graph = [
+        [0, 5, float('inf'), 10],
+        [float('inf'), 0, 3, float('inf')],
+        [float('inf'), float('inf'), 0, 1],
+        [float('inf'), float('inf'), float('inf'), 0]
+    ]
+    expected = [
+        [0, 5, 8, 9],
+        [float('inf'), 0, 3, 4],
+        [float('inf'), float('inf'), 0, 1],
+        [float('inf'), float('inf'), float('inf'), 0]
+    ]
+    result = floyd_warshall(graph)
+    assert result == expected
+
+def test_floyd_warshall_disconnected_graph():
+    """Test Floyd-Warshall on a graph with disconnected vertices."""
+    graph = [
+        [0, 5, float('inf')],
+        [float('inf'), 0, float('inf')],
+        [float('inf'), float('inf'), 0]
+    ]
+    expected = [
+        [0, 5, float('inf')],
+        [float('inf'), 0, float('inf')],
+        [float('inf'), float('inf'), 0]
+    ]
+    result = floyd_warshall(graph)
+    assert result == expected
+
+def test_floyd_warshall_negative_weights():
+    """Test Floyd-Warshall with a graph containing negative weights."""
+    graph = [
+        [0, -1, 4],
+        [float('inf'), 0, 3],
+        [float('inf'), float('inf'), 0]
+    ]
+    expected = [
+        [0, -1, 2],
+        [float('inf'), 0, 3],
+        [float('inf'), float('inf'), 0]
+    ]
+    result = floyd_warshall(graph)
+    assert result == expected
+
+def test_floyd_warshall_empty_graph():
+    """Test Floyd-Warshall with an empty graph."""
+    with pytest.raises(ValueError, match="Graph cannot be empty"):
+        floyd_warshall([])
+
+def test_floyd_warshall_non_square_matrix():
+    """Test Floyd-Warshall with a non-square matrix."""
+    with pytest.raises(ValueError, match="Graph must be a square matrix"):
+        floyd_warshall([
+            [0, 1, 2],
+            [float('inf'), 0]
+        ])
+
+def test_floyd_warshall_single_vertex():
+    """Test Floyd-Warshall with a single vertex graph."""
+    graph = [[0]]
+    result = floyd_warshall(graph)
+    assert result == [[0]]
+
+def test_floyd_warshall_negative_cycle():
+    """Test Floyd-Warshall with a graph containing a negative cycle."""
+    graph = [
+        [0, 1, float('inf')],
+        [float('inf'), 0, -3],
+        [-1, float('inf'), 0]
+    ]
+    result = floyd_warshall(graph)
+    assert result is None


### PR DESCRIPTION
# Implement Floyd-Warshall Algorithm for Shortest Paths

## Original Task
Write a function to implement the Floyd-Warshall algorithm for shortest paths.

## Summary of Changes
Added implementation of Floyd-Warshall algorithm to compute shortest paths between all pairs of vertices in a weighted graph.

## Acceptance Criteria
All tests must pass.

## Tests
 - Test function handles different graph sizes
 - Test function handles graphs with positive and negative edge weights
 - Test function correctly computes shortest paths between all vertex pairs
 - Test function handles disconnected graphs
