### PR TITLE
Implement BFS Shortest Path Algorithm for Unweighted Graphs

### DIFF
--- a/src/bfs_shortest_path.py
+++ b/src/bfs_shortest_path.py
@@ -1,0 +1,59 @@
+from collections import deque
+from typing import List, Dict, Optional, Union
+
+def find_shortest_path(graph: Dict[Union[int, str], List[Union[int, str]]], 
+                       start: Union[int, str], 
+                       end: Union[int, str]) -> Optional[List[Union[int, str]]]:
+    """
+    Find the shortest path between start and end nodes in an unweighted graph using BFS.
+    
+    Args:
+        graph (Dict): Adjacency list representing the graph
+        start (int/str): Starting node 
+        end (int/str): Destination node
+    
+    Returns:
+        Optional[List]: Shortest path from start to end, or None if no path exists
+    
+    Raises:
+        ValueError: If start or end nodes are not in the graph
+    """
+    # Validate input nodes exist in the graph
+    if start not in graph:
+        raise ValueError(f"Start node {start} not found in graph")
+    if end not in graph:
+        raise ValueError(f"End node {end} not found in graph")
+    
+    # Special case: start and end are the same
+    if start == end:
+        return [start]
+    
+    # Queue for BFS
+    queue = deque([(start, [start])])
+    
+    # Track visited nodes to prevent cycles
+    visited = set([start])
+    
+    # BFS traversal
+    while queue:
+        current_node, path = queue.popleft()
+        
+        # Check neighbors
+        for neighbor in graph.get(current_node, []):
+            # Skip already visited nodes
+            if neighbor in visited:
+                continue
+            
+            # New path to this neighbor
+            new_path = path + [neighbor]
+            
+            # Found the destination
+            if neighbor == end:
+                return new_path
+            
+            # Mark as visited and add to queue
+            visited.add(neighbor)
+            queue.append((neighbor, new_path))
+    
+    # No path found
+    return None

--- a/tests/test_bfs_shortest_path.py
+++ b/tests/test_bfs_shortest_path.py
@@ -1,0 +1,83 @@
+import pytest
+from src.bfs_shortest_path import find_shortest_path
+
+def test_basic_path():
+    graph = {
+        'A': ['B', 'C'],
+        'B': ['A', 'D', 'E'],
+        'C': ['A', 'F'],
+        'D': ['B'],
+        'E': ['B', 'F'],
+        'F': ['C', 'E']
+    }
+    assert find_shortest_path(graph, 'A', 'F') == ['A', 'C', 'F']
+
+def test_same_node():
+    graph = {
+        'A': ['B', 'C'],
+        'B': ['A'],
+        'C': ['B']
+    }
+    assert find_shortest_path(graph, 'A', 'A') == ['A']
+
+def test_direct_connection():
+    graph = {
+        'A': ['B', 'C'],
+        'B': ['A', 'D'],
+        'C': ['A'],
+        'D': ['B']
+    }
+    assert find_shortest_path(graph, 'A', 'B') == ['A', 'B']
+
+def test_no_path():
+    graph = {
+        'A': ['B'],
+        'B': ['A'],
+        'C': ['D'],
+        'D': ['C']
+    }
+    assert find_shortest_path(graph, 'A', 'C') is None
+
+def test_numeric_nodes():
+    graph = {
+        1: [2, 3],
+        2: [1, 4, 5],
+        3: [1, 6],
+        4: [2],
+        5: [2, 6],
+        6: [3, 5]
+    }
+    assert find_shortest_path(graph, 1, 6) == [1, 3, 6]
+
+def test_invalid_start_node():
+    graph = {
+        'A': ['B', 'C'],
+        'B': ['A'],
+        'C': ['B']
+    }
+    with pytest.raises(ValueError, match="Start node X not found in graph"):
+        find_shortest_path(graph, 'X', 'A')
+
+def test_invalid_end_node():
+    graph = {
+        'A': ['B', 'C'],
+        'B': ['A'],
+        'C': ['B']
+    }
+    with pytest.raises(ValueError, match="End node X not found in graph"):
+        find_shortest_path(graph, 'A', 'X')
+
+def test_empty_graph():
+    graph = {}
+    with pytest.raises(ValueError, match="Start node A not found in graph"):
+        find_shortest_path(graph, 'A', 'B')
+
+def test_multiple_shortest_paths():
+    graph = {
+        'A': ['B', 'C'],
+        'B': ['A', 'D'],
+        'C': ['A', 'D'],
+        'D': ['B', 'C']
+    }
+    path = find_shortest_path(graph, 'A', 'D')
+    assert path in [['A', 'B', 'D'], ['A', 'C', 'D']]


### PR DESCRIPTION
# Implement BFS Shortest Path Algorithm for Unweighted Graphs

## Original Task
Write a function to find the shortest path in an unweighted graph using BFS.

## Summary of Changes
Added a comprehensive implementation of Breadth-First Search (BFS) algorithm to find the shortest path in an unweighted graph.

## Acceptance Criteria
All tests must pass.

## Tests
 - Verify the BFS shortest path function returns the correct shortest path between two nodes
 - Check that the function handles graphs with multiple possible paths
 - Ensure the function works with disconnected graphs
 - Test edge cases like start and end nodes being the same
 - Validate path length calculation
