### PR TITLE
Implement Function to Count Weekends in a Month

### DIFF
--- a/src/weekend_counter.py
+++ b/src/weekend_counter.py
@@ -1,0 +1,35 @@
+import calendar
+from datetime import date
+
+def count_weekends_in_month(year: int, month: int) -> int:
+    """
+    Count the number of weekend days (Saturdays and Sundays) in a given month.
+
+    Args:
+        year (int): The year to check (e.g., 2023)
+        month (int): The month to check (1-12)
+
+    Returns:
+        int: Number of weekend days in the specified month
+
+    Raises:
+        ValueError: If the month is not between 1 and 12
+    """
+    # Validate month input
+    if not 1 <= month <= 12:
+        raise ValueError("Month must be between 1 and 12")
+
+    # Get the number of days in the month
+    _, num_days = calendar.monthrange(year, month)
+
+    # Count weekend days
+    weekend_count = 0
+    for day in range(1, num_days + 1):
+        # Create a date object for each day in the month
+        current_date = date(year, month, day)
+        
+        # Check if the day is a Saturday (5) or Sunday (6)
+        if current_date.weekday() in [5, 6]:
+            weekend_count += 1
+
+    return weekend_count

--- a/tests/test_weekend_counter.py
+++ b/tests/test_weekend_counter.py
@@ -18,13 +18,13 @@ def test_february_non_leap_year():
 
 def test_month_with_31_days():
     """Test a month with 31 days."""
-    # March 2023 has 10 weekend days
-    assert count_weekends_in_month(2023, 3) == 10
+    # March 2023 has 8 weekend days
+    assert count_weekends_in_month(2023, 3) == 8
 
 def test_month_with_30_days():
     """Test a month with 30 days."""
-    # April 2023 has 8 weekend days
-    assert count_weekends_in_month(2023, 4) == 8
+    # April 2023 has 10 weekend days
+    assert count_weekends_in_month(2023, 4) == 10
 
 def test_invalid_month_low():
     """Test handling of invalid low month input."""

--- a/tests/test_weekend_counter.py
+++ b/tests/test_weekend_counter.py
@@ -1,0 +1,37 @@
+import pytest
+from src.weekend_counter import count_weekends_in_month
+
+def test_typical_month():
+    """Test a typical month with both weekend and weekdays."""
+    # January 2023 has 9 weekend days
+    assert count_weekends_in_month(2023, 1) == 9
+
+def test_february_leap_year():
+    """Test February in a leap year."""
+    # February 2024 (leap year) has 8 weekend days
+    assert count_weekends_in_month(2024, 2) == 8
+
+def test_february_non_leap_year():
+    """Test February in a non-leap year."""
+    # February 2023 (non-leap year) has 8 weekend days
+    assert count_weekends_in_month(2023, 2) == 8
+
+def test_month_with_31_days():
+    """Test a month with 31 days."""
+    # March 2023 has 10 weekend days
+    assert count_weekends_in_month(2023, 3) == 10
+
+def test_month_with_30_days():
+    """Test a month with 30 days."""
+    # April 2023 has 8 weekend days
+    assert count_weekends_in_month(2023, 4) == 8
+
+def test_invalid_month_low():
+    """Test handling of invalid low month input."""
+    with pytest.raises(ValueError, match="Month must be between 1 and 12"):
+        count_weekends_in_month(2023, 0)
+
+def test_invalid_month_high():
+    """Test handling of invalid high month input."""
+    with pytest.raises(ValueError, match="Month must be between 1 and 12"):
+        count_weekends_in_month(2023, 13)


### PR DESCRIPTION
# Implement Function to Count Weekends in a Month

## Original Task
Write a function to determine the number of weekends in a given month.

## Summary of Changes
Added a new utility function to calculate the number of weekend days (Saturdays and Sundays) in a specific month and year.

## Acceptance Criteria
All tests must pass.

## Tests
 - Verify the function correctly counts weekends for different months
 - Check edge cases like months with 30 and 31 days
 - Ensure accuracy across leap years and non-leap years
