### PR TITLE
Implement Permission-Based Console Message Logging

### DIFF
--- a/src/permission_logger.py
+++ b/src/permission_logger.py
@@ -1,0 +1,77 @@
+import logging
+from enum import Enum
+from typing import Optional, Union
+
+class UserPermissionLevel(Enum):
+    """Enum representing different user permission levels."""
+    GUEST = 1
+    USER = 2
+    ADMIN = 3
+
+class PermissionLogger:
+    """
+    A logger that controls message logging based on user permission levels.
+    
+    The logger allows logging messages only if the user's permission level 
+    meets or exceeds the specified log level.
+    """
+    
+    def __init__(self, min_permission_level: UserPermissionLevel = UserPermissionLevel.USER):
+        """
+        Initialize the PermissionLogger.
+        
+        Args:
+            min_permission_level (UserPermissionLevel, optional): 
+                Minimum permission level required to log messages. 
+                Defaults to UserPermissionLevel.USER.
+        """
+        self._min_permission_level = min_permission_level
+        self._logger = logging.getLogger(__name__)
+        
+        # Configure basic logging if not already configured
+        if not self._logger.handlers:
+            logging.basicConfig(
+                level=logging.INFO,
+                format='%(asctime)s - %(levelname)s - %(message)s'
+            )
+    
+    def log(self, 
+            message: str, 
+            user_permission: Optional[UserPermissionLevel] = None, 
+            level: int = logging.INFO
+    ) -> bool:
+        """
+        Log a message based on user permissions.
+        
+        Args:
+            message (str): The message to log
+            user_permission (Optional[UserPermissionLevel], optional): 
+                User's permission level. If None, uses the logger's default.
+            level (int, optional): Logging level. Defaults to logging.INFO.
+        
+        Returns:
+            bool: True if message was logged, False otherwise
+        
+        Raises:
+            ValueError: If message is empty
+            TypeError: If user_permission is not a UserPermissionLevel
+        """
+        # Validate input
+        if not message:
+            raise ValueError("Message cannot be empty")
+        
+        # Use default min permission if not specified
+        if user_permission is None:
+            user_permission = self._min_permission_level
+        
+        # Validate user permission
+        if not isinstance(user_permission, UserPermissionLevel):
+            raise TypeError("user_permission must be a UserPermissionLevel")
+        
+        # Check if user has sufficient permissions to log
+        if user_permission.value >= self._min_permission_level.value:
+            # Log the message
+            self._logger.log(level, message)
+            return True
+        
+        return False

--- a/tests/test_permission_logger.py
+++ b/tests/test_permission_logger.py
@@ -1,0 +1,73 @@
+import pytest
+import logging
+from src.permission_logger import PermissionLogger, UserPermissionLevel
+
+class TestPermissionLogger:
+    def test_default_initialization(self):
+        """Test default logger initialization."""
+        logger = PermissionLogger()
+        assert logger._min_permission_level == UserPermissionLevel.USER
+    
+    def test_custom_initialization(self):
+        """Test custom logger initialization."""
+        logger = PermissionLogger(min_permission_level=UserPermissionLevel.ADMIN)
+        assert logger._min_permission_level == UserPermissionLevel.ADMIN
+    
+    def test_successful_log_with_sufficient_permissions(self, caplog):
+        """Test logging with sufficient permissions."""
+        logger = PermissionLogger(min_permission_level=UserPermissionLevel.USER)
+        caplog.set_level(logging.INFO)
+        
+        result = logger.log("Test message", user_permission=UserPermissionLevel.USER)
+        assert result is True
+        assert "Test message" in caplog.text
+    
+    def test_log_with_higher_permissions(self, caplog):
+        """Test logging with higher than required permissions."""
+        logger = PermissionLogger(min_permission_level=UserPermissionLevel.USER)
+        caplog.set_level(logging.INFO)
+        
+        result = logger.log("Admin message", user_permission=UserPermissionLevel.ADMIN)
+        assert result is True
+        assert "Admin message" in caplog.text
+    
+    def test_log_with_insufficient_permissions(self, caplog):
+        """Test logging with insufficient permissions."""
+        logger = PermissionLogger(min_permission_level=UserPermissionLevel.ADMIN)
+        caplog.set_level(logging.INFO)
+        
+        result = logger.log("Guest message", user_permission=UserPermissionLevel.GUEST)
+        assert result is False
+        assert "Guest message" not in caplog.text
+    
+    def test_log_with_default_permission(self, caplog):
+        """Test logging with default permissions."""
+        logger = PermissionLogger(min_permission_level=UserPermissionLevel.USER)
+        caplog.set_level(logging.INFO)
+        
+        result = logger.log("Default message")
+        assert result is True
+        assert "Default message" in caplog.text
+    
+    def test_empty_message_raises_error(self):
+        """Test that empty message raises ValueError."""
+        logger = PermissionLogger()
+        
+        with pytest.raises(ValueError, match="Message cannot be empty"):
+            logger.log("")
+    
+    def test_invalid_permission_type_raises_error(self):
+        """Test that invalid permission type raises TypeError."""
+        logger = PermissionLogger()
+        
+        with pytest.raises(TypeError, match="user_permission must be a UserPermissionLevel"):
+            logger.log("Test message", user_permission="not a permission")
+    
+    def test_custom_log_level(self, caplog):
+        """Test logging with a custom log level."""
+        logger = PermissionLogger()
+        caplog.set_level(logging.WARNING)
+        
+        result = logger.log("Warning message", level=logging.WARNING)
+        assert result is True
+        assert "Warning message" in caplog.text


### PR DESCRIPTION
# Implement Permission-Based Console Message Logging

## Original Task
Write a function to log console messages based on user permissions.

## Summary of Changes
Added a new logging mechanism that restricts console message logging based on user permission levels, enhancing system security and log management.

## Acceptance Criteria
All tests must pass.

## Tests
 - Verify that messages are logged only for users with appropriate permission levels
 - Confirm that unauthorized users cannot log messages
 - Check that the logging function handles different permission scenarios correctly
